### PR TITLE
Add custom port to prisma studio command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "NODE_OPTIONS='--inspect' next dev -p ${PORT:-3000}",
     "build": "next build",
     "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
-    "db": "prisma studio",
+    "db": "prisma studio --port 7777",
     "db:up": "docker-compose --project-name=resilience-web up -d",
     "db:down": "docker-compose --project-name=resilience-web down",
     "postinstall": "prisma generate",


### PR DESCRIPTION
Looks like the Android emulator uses the same port (5555) so changing this so they don't interfere on my work computer.