### PR TITLE
Fix listing status badge rendering issues

### DIFF
--- a/app/api/listing/[id]/status-badge/route.ts
+++ b/app/api/listing/[id]/status-badge/route.ts
@@ -6,94 +6,118 @@ import prisma from '@prisma-rw'
 // Sharp requires the Node.js runtime
 export const runtime = 'nodejs'
 
-function generateStatusSVG({
+async function generateBadgePNG({
   text,
   approved,
-  width = 100,
-  height = 30,
 }: {
   text: string
   approved: boolean
-  width?: number
-  height?: number
+}): Promise<Buffer> {
+  const bgColor = approved
+    ? { r: 22, g: 163, b: 74 }
+    : { r: 156, g: 163, b: 175 }
+  const borderColor = approved
+    ? { r: 21, g: 128, b: 61 }
+    : { r: 107, g: 114, b: 128 }
+
+  // Calculate dimensions based on text length
+  const charWidth = 8
+  const padding = 24
+  const width = Math.max(120, text.length * charWidth + padding * 2)
+  const height = 32
+  const borderRadius = 6
+
+  // Create the main badge background with rounded corners
+  const badge = sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: bgColor,
+    },
+  }).png()
+
+  // Create border overlay
+  const borderSvg = `
+    <svg width="${width}" height="${height}">
+      <rect x="1" y="1" width="${width - 2}" height="${height - 2}" 
+            rx="${borderRadius}" ry="${borderRadius}" 
+            fill="none" stroke="rgb(${borderColor.r},${borderColor.g},${borderColor.b})" 
+            stroke-width="2"/>
+    </svg>
+  `
+
+  // Create text overlay using SVG (Sharp can render SVG text with embedded fonts)
+  const textSvg = `
+    <svg width="${width}" height="${height}">
+      <style>
+        .badge-text { 
+          fill: white; 
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+          font-size: 14px; 
+          font-weight: 600;
+        }
+      </style>
+      <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" class="badge-text">
+        ${text}
+      </text>
+    </svg>
+  `
+
+  // Composite everything together
+  const result = await badge
+    .composite([
+      {
+        input: Buffer.from(borderSvg),
+        top: 0,
+        left: 0,
+      },
+      {
+        input: Buffer.from(textSvg),
+        top: 0,
+        left: 0,
+      },
+    ])
+    .png({ compressionLevel: 9, quality: 90 })
+    .toBuffer()
+
+  return result
+}
+
+function generateStatusSVG({
+  text,
+  approved,
+}: {
+  text: string
+  approved: boolean
 }) {
-  const bg = approved ? '#16a34a' : '#9ca3af' // green-600 or gray-400
-  const textColor = '#ffffff'
-  const border = approved ? '#15803d' : '#6b7280' // darker border
+  const bg = approved ? '#16a34a' : '#9ca3af'
+  const border = approved ? '#15803d' : '#6b7280'
 
-  // Dynamic sizing and optional wrapping
-  const paddingX = 16
-  const paddingY = 16
-  let lines: string[] = [text]
-
-  // Decide if a single line would be too constrained by width; if so, try to split into two lines
-  if (text.includes(' ')) {
-    const mid = Math.floor(text.length / 2)
-    let splitIdx = text.lastIndexOf(' ', mid)
-    if (splitIdx === -1) splitIdx = text.indexOf(' ', mid)
-    if (splitIdx !== -1 && splitIdx > 0 && splitIdx < text.length - 1) {
-      const l1 = text.slice(0, splitIdx)
-      const l2 = text.slice(splitIdx + 1)
-      // Only accept split if it makes lines more balanced
-      const balanced =
-        Math.abs(l1.length - l2.length) <= Math.ceil(text.length * 0.5)
-      // Estimate single-line max font size by width for the full text
-      const singleLineMaxByWidth = Math.floor(
-        (width - paddingX * 2) / (0.62 * Math.max(1, text.length)),
-      )
-      const widthTarget = Math.round(width * 0.16)
-      if (balanced || singleLineMaxByWidth < widthTarget) {
-        lines = [l1.trim(), l2.trim()]
-      }
-    }
-  }
-
-  const longest = lines.reduce((a, b) => (a.length > b.length ? a : b), '')
-  // Approximate average glyph width ~ 0.62em, and vertical line-height ~ 1.2em
-  const maxByWidth = Math.floor(
-    (width - paddingX * 2) / (0.62 * Math.max(1, longest.length)),
-  )
-  const maxByHeight = Math.floor((height - paddingY * 2) / (1.2 * lines.length))
-
-  let fontSize = Math.min(
-    56,
-    Math.round(width * 0.16),
-    Math.round(height * 0.6),
-  )
-  fontSize = Math.min(fontSize, maxByWidth, maxByHeight)
-  fontSize = Math.max(fontSize, 12) // keep readable minimum
-
-  const textNode =
-    lines.length === 1
-      ? `<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="${textColor}" font-size="${fontSize}" font-weight="700">${text}</text>`
-      : `<text x="50%" y="50%" text-anchor="middle" fill="${textColor}" font-size="${fontSize}" font-weight="700">
-           <tspan x="50%" dy="-0.6em">${lines[0]}</tspan>
-           <tspan x="50%" dy="1.2em">${lines[1]}</tspan>
-         </text>`
+  // Calculate dimensions based on text length
+  const charWidth = 8
+  const padding = 24
+  const width = Math.max(120, text.length * charWidth + padding * 2)
+  const height = 32
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
   <defs>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000000" flood-opacity="0.2"/>
-    </filter>
+    <style>
+      .badge-text { 
+        fill: white; 
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-size: 14px; 
+        font-weight: 600;
+      }
+    </style>
   </defs>
-  <rect x="4" y="4" rx="16" ry="16" width="${width - 8}" height="${height - 8}" fill="${bg}" stroke="${border}" stroke-width="2" filter="url(#shadow)"/>
-  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', sans-serif">
-    ${textNode}
-  </g>
+  <rect x="1" y="1" rx="6" ry="6" width="${width - 2}" height="${height - 2}" 
+        fill="${bg}" stroke="${border}" stroke-width="2"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" class="badge-text">
+    ${text}
+  </text>
 </svg>`
-}
-
-async function svgToPng(svg: string): Promise<ArrayBuffer> {
-  const buffer = Buffer.from(svg)
-  const pngBuffer = await sharp(buffer)
-    .png({ compressionLevel: 9, quality: 90 })
-    .toBuffer()
-  // Copy into a fresh ArrayBuffer to avoid SharedArrayBuffer typing issues
-  const ab = new ArrayBuffer(pngBuffer.length)
-  new Uint8Array(ab).set(pngBuffer)
-  return ab
 }
 
 export async function GET(
@@ -115,13 +139,10 @@ export async function GET(
     })
 
     if (!listing) {
-      const svg = generateStatusSVG({
-        text: 'Listing not found',
-        approved: false,
-      })
+      const text = 'Listing not found'
       if (format === 'png') {
-        const png = await svgToPng(svg)
-        return new Response(png, {
+        const pngBuffer = await generateBadgePNG({ text, approved: false })
+        return new Response(new Uint8Array(pngBuffer), {
           status: 404,
           headers: {
             'Content-Type': 'image/png',
@@ -129,6 +150,7 @@ export async function GET(
           },
         })
       } else {
+        const svg = generateStatusSVG({ text, approved: false })
         return new Response(svg, {
           status: 404,
           headers: {
@@ -141,10 +163,10 @@ export async function GET(
 
     const approved = !listing.pending
     const text = approved ? 'Approved' : 'Not approved yet'
-    const svg = generateStatusSVG({ text, approved })
+
     if (format === 'png') {
-      const png = await svgToPng(svg)
-      return new Response(png, {
+      const pngBuffer = await generateBadgePNG({ text, approved })
+      return new Response(new Uint8Array(pngBuffer), {
         headers: {
           'Content-Type': 'image/png',
           'Cache-Control':
@@ -152,6 +174,7 @@ export async function GET(
         },
       })
     } else {
+      const svg = generateStatusSVG({ text, approved })
       return new Response(svg, {
         headers: {
           'Content-Type': 'image/svg+xml; charset=utf-8',


### PR DESCRIPTION
This badge is used to render in proposed listing emails to let others know whether the listing was already approved or not.

Before
<img width="164" height="51" alt="image" src="https://github.com/user-attachments/assets/4828e2b9-0f70-45c6-b4a1-ce9d44c7ae79" />

After
<img width="207" height="60" alt="image" src="https://github.com/user-attachments/assets/0fb257e3-3e4b-498c-8dae-9f994b6e39b6" />

Same for approved status.