### PR TITLE
Allow adding tags from public edit listing page + various other fixes

### DIFF
--- a/app/Homepage.tsx
+++ b/app/Homepage.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import Features from '@components/homepage/features'
 import Hero from '@components/homepage/hero'
 import JoinTheCommunity from '@components/homepage/join-the-community'
-import WebCards from '@components/homepage/web-cards'
+import WebCards, { isWebDisplayedOnHomepage } from '@components/homepage/web-cards'
 import Layout from '@components/layout'
 
 const WebsMap = dynamic(() => import('@components/homepage/webs-map'), {
@@ -19,7 +19,7 @@ interface HomepageProps {
 export default function Homepage({ webs, showMap = false }: HomepageProps) {
   return (
     <Layout webs={webs}>
-      <Hero webCount={webs.length} />
+      <Hero webCount={webs.filter(isWebDisplayedOnHomepage).length} />
       {showMap ? <WebsMap webs={webs} /> : <WebCards webs={webs} />}
       <Features />
       <JoinTheCommunity />

--- a/app/[subdomain]/Web.tsx
+++ b/app/[subdomain]/Web.tsx
@@ -305,7 +305,7 @@ const Web = ({
 
   return (
     <>
-      {!isMobile && (
+      <div className="hidden md:block">
         <Drawer
           categories={categories}
           selectedCategories={selectedCategories}
@@ -323,7 +323,7 @@ const Web = ({
           webSlug={webSlug}
           isTransitionMode={isTransitionMode}
         />
-      )}
+      </div>
       <div
         className={`relative flex flex-col md:ml-75 ${
           activeTab === 'web' || activeTab === 'map'

--- a/app/[subdomain]/Web.tsx
+++ b/app/[subdomain]/Web.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, memo, useState } from 'react'
+import { HiOutlineShare } from 'react-icons/hi'
 import dynamic from 'next/dynamic'
+import NextLink from 'next/link'
 import '@styles/font-awesome.css'
 import { useQueryState, parseAsArrayOf, parseAsString } from 'nuqs'
 import { useDebounceValue, useLocalStorage } from 'usehooks-ts'
 import { trackWebEvent } from '@helpers/analytics'
+import { REMOTE_URL } from '@helpers/config'
 import { isFeatureEnabled, FEATURES } from '@helpers/features'
 import {
   removeNonAlphaNumeric,
@@ -18,6 +21,7 @@ import Events from '@components/events'
 import Header from '@components/header'
 import { License, LicenseTransition } from '@components/license'
 import MainList from '@components/main-list'
+import { Button } from '@components/ui/button'
 import { Spinner } from '@components/ui/spinner'
 import useIsMobile from '@hooks/application/useIsMobile'
 import useCategoriesPublic from '@hooks/categories/useCategoriesPublic'
@@ -286,6 +290,19 @@ const Web = ({
     [data?.edges, filteredItems, filteredDescriptiveNodes],
   )
 
+  const totalListingsCount = useMemo(
+    () =>
+      data?.nodes.filter(
+        (item) =>
+          item.group !== 'category' &&
+          item.group !== 'central-node' &&
+          item.group !== 'related-web',
+      ).length ?? 0,
+    [data?.nodes],
+  )
+
+  const isWebEmpty = filteredItems.length === 0
+
   return (
     <>
       {!isMobile && (
@@ -342,14 +359,49 @@ const Web = ({
           onTabChange={handleTabChange}
         />
 
-        {activeTab === 'web' && (
-          <NetworkComponent
-            data={filteredNetworkData}
-            selectedId={selectedId}
-            setSelectedId={setSelectedId}
-            webId={webId}
-          />
-        )}
+        {activeTab === 'web' &&
+          (isWebEmpty ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 py-12 text-center">
+              <div className="bg-primary/10 text-primary flex h-16 w-16 items-center justify-center rounded-full">
+                <HiOutlineShare className="h-8 w-8" />
+              </div>
+              {totalListingsCount === 0 ? (
+                <>
+                  <h2 className="text-xl font-semibold">
+                    This web doesn't have any listings yet
+                  </h2>
+                  <p className="text-muted-foreground max-w-105 text-balance">
+                    Once listings are added they'll appear here as an
+                    interconnected web. Know a group that belongs here? Propose
+                    it and help {webName} Resilience Web grow.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h2 className="text-xl font-semibold">No listings to show</h2>
+                  <p className="text-muted-foreground max-w-105">
+                    No listings match your current filters or search. Try
+                    clearing them, or propose a listing to the maintainers.
+                  </p>
+                </>
+              )}
+              <NextLink href={`${REMOTE_URL}/new-listing/${webSlug}`}>
+                <Button
+                  variant="default"
+                  className="bg-primary hover:bg-primary/90"
+                >
+                  Propose new listing
+                </Button>
+              </NextLink>
+            </div>
+          ) : (
+            <NetworkComponent
+              data={filteredNetworkData}
+              selectedId={selectedId}
+              setSelectedId={setSelectedId}
+              webId={webId}
+            />
+          ))}
 
         {activeTab === 'list' && (
           <MainList filteredItems={filteredItems} webSlug={webSlug} />

--- a/app/api/listing/[id]/apply-edit/route.ts
+++ b/app/api/listing/[id]/apply-edit/route.ts
@@ -33,6 +33,7 @@ export async function POST(
         user: true,
         socials: true,
         actions: true,
+        tags: true,
         category: true,
         location: true,
         web: true,
@@ -141,6 +142,12 @@ export async function POST(
         data: {
           ...(listingEdit.categoryId
             ? { category: { connect: { id: listingEdit.categoryId } } }
+            : {}),
+          // Only overwrite tags when the edit actually carried some, so that
+          // approving legacy edits (created before tag support) doesn't wipe
+          // the placement's existing tags.
+          ...(listingEdit.tags.length > 0
+            ? { tags: { set: listingEdit.tags.map((t) => ({ id: t.id })) } }
             : {}),
         },
       }),

--- a/app/api/listings/[slug]/edit/route.ts
+++ b/app/api/listings/[slug]/edit/route.ts
@@ -70,6 +70,8 @@ export async function POST(request, props) {
     const socialsData = socials ? JSON.parse(socials) : []
     const actions = formData.get('actions')
     const actionsData = actions ? JSON.parse(actions) : []
+    const tags = formData.get('tags')
+    const tagsData: number[] = tags ? JSON.parse(tags) : []
     const latitude = formData.get('latitude')
     const longitude = formData.get('longitude')
     const locationDescription = formData.get('locationDescription')
@@ -153,6 +155,9 @@ export async function POST(request, props) {
           type: action.type,
           url: action.url,
         })),
+      },
+      tags: {
+        connect: tagsData.map((id) => ({ id })),
       },
       location: locationData,
     }

--- a/app/api/webs/route.ts
+++ b/app/api/webs/route.ts
@@ -94,9 +94,12 @@ export async function GET(request: NextRequest) {
   } catch (e) {
     console.error(`[RW] Unable to fetch webs - ${e}`)
     Sentry.captureException(e)
-    return new Response(`Unable to fetch webs - ${e}`, {
-      status: 500,
-    })
+    return Response.json(
+      { error: `Unable to fetch webs - ${e}` },
+      {
+        status: 500,
+      },
+    )
   }
 }
 
@@ -185,8 +188,8 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     if (error.code === 'P2002') {
-      return new Response(
-        'Sorry, a web with the same title or link already exists',
+      return Response.json(
+        { error: 'A web with the same title or link already exists.' },
         {
           status: 409,
         },
@@ -194,9 +197,12 @@ export async function POST(request: NextRequest) {
     } else {
       console.error(`[RW] Unable to create web - ${error}`)
       Sentry.captureException(error)
-      return new Response(`Unable to create web - ${error}`, {
-        status: 500,
-      })
+      return Response.json(
+        { error: `Unable to create web - ${error}` },
+        {
+          status: 500,
+        },
+      )
     }
   }
 }

--- a/app/edit/[webSlug]/[listingSlug]/EditListing.tsx
+++ b/app/edit/[webSlug]/[listingSlug]/EditListing.tsx
@@ -28,6 +28,7 @@ export default function EditListing({ listing, webSlug }) {
   const handleSubmit = useCallback(
     (data) => {
       data.webId = web?.id
+      data.webSlug = webSlug
       data.listingId = listing.id
       data.inactive = false
       data.relations = []
@@ -39,7 +40,7 @@ export default function EditListing({ listing, webSlug }) {
         }
       }, 1000)
     },
-    [web?.id, listing.id, createListingEdit],
+    [web?.id, webSlug, listing.id, createListingEdit],
   )
 
   if (isCategoriesLoading || isLoadingEdits) {

--- a/components/admin/listing-form/ListingFormSimplified.tsx
+++ b/components/admin/listing-form/ListingFormSimplified.tsx
@@ -141,14 +141,14 @@ const ListingFormSimplified = ({
   isEditMode = false,
   webSlug,
 }: Props) => {
-  const { tags } = useTags()
+  const { tags } = useTags({ webSlug })
   const form = useForm({
     resolver: zodResolver(listingFormSchema),
     defaultValues: {
       id: listing?.id || null,
       title: listing?.title ?? '',
       description: listing?.description || '',
-      category: listing?.categoryId || undefined,
+      category: listing?.category?.id || listing?.categoryId || undefined,
       email: listing?.email || '',
       website: listing?.website || '',
       socials: listing?.socials || [],
@@ -156,7 +156,7 @@ const ListingFormSimplified = ({
       seekingVolunteers: listing?.seekingVolunteers || false,
       image: listing?.image,
       slug: listing?.slug || '',
-      tags: [],
+      tags: listing?.tags?.map((t) => ({ value: t.id, label: t.label })) || [],
       noPhysicalLocation: listing?.location?.noPhysicalLocation || false,
       location:
         listing?.location?.latitude && listing?.location?.longitude

--- a/components/admin/listing-form/listing-edit-review/ListingEditReview.tsx
+++ b/components/admin/listing-form/listing-edit-review/ListingEditReview.tsx
@@ -7,6 +7,7 @@ import useDeleteListingEdit from '@hooks/listings/useDeleteListingEdit'
 import ActionEdits from './ActionEdits'
 import Diff from './Diff'
 import SocialMediaEdits from './SocialMediaEdits'
+import TagEdits from './TagEdits'
 
 const ListingMap = dynamic(() => import('@components/listing-map'), {
   ssr: false,
@@ -145,6 +146,8 @@ const ListingEditReview = ({
       <SocialMediaEdits listing={listing} editedListing={editedListing} />
 
       <ActionEdits listing={listing} editedListing={editedListing} />
+
+      <TagEdits listing={listing} editedListing={editedListing} />
 
       {listing.location?.description !==
         editedListing.location?.description && (

--- a/components/admin/listing-form/listing-edit-review/TagEdits.tsx
+++ b/components/admin/listing-form/listing-edit-review/TagEdits.tsx
@@ -1,0 +1,84 @@
+import { memo } from 'react'
+
+interface Tag {
+  id: number
+  label: string
+}
+
+interface Props {
+  listing: Listing
+  editedListing: Listing
+}
+
+const TagEdits = ({ listing, editedListing }: Props) => {
+  const currentTags: Tag[] = listing.tags ?? []
+  const editedTags: Tag[] = editedListing.tags ?? []
+
+  if (!currentTags.length && !editedTags.length) {
+    return null
+  }
+
+  const editedTagIds = new Set(editedTags.map((t) => t.id))
+  const currentTagIds = new Set(currentTags.map((t) => t.id))
+
+  const removedTags = currentTags.filter((t) => !editedTagIds.has(t.id))
+  const addedTags = editedTags.filter((t) => !currentTagIds.has(t.id))
+  const unchangedTags = currentTags.filter((t) => editedTagIds.has(t.id))
+
+  // Nothing changed — don't render a section.
+  if (!removedTags.length && !addedTags.length) {
+    return null
+  }
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      <h3 className="mt-2 text-lg font-semibold">Tags</h3>
+
+      {addedTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-green-700">Added:</span>
+          {addedTags.map((tag) => (
+            <span
+              key={tag.id}
+              className="rounded-full px-3 py-1 text-sm"
+              style={{ color: 'green', backgroundColor: '#b5efdb' }}
+            >
+              + {tag.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {removedTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-red-700">Removed:</span>
+          {removedTags.map((tag) => (
+            <span
+              key={tag.id}
+              className="rounded-full px-3 py-1 text-sm line-through"
+              style={{ color: 'red', backgroundColor: '#fec4c0' }}
+            >
+              {tag.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {unchangedTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-gray-500">Unchanged:</span>
+          {unchangedTags.map((tag) => (
+            <span
+              key={tag.id}
+              className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"
+            >
+              {tag.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default memo(TagEdits)

--- a/components/admin/web-features/WebFeatures.tsx
+++ b/components/admin/web-features/WebFeatures.tsx
@@ -26,9 +26,11 @@ export default function WebFeatures({ web }: WebFeaturesProps) {
   const handleFeatureToggle = (featureKey: string, enabled: boolean) => {
     try {
       setFeatures((prevFeatures) =>
-        prevFeatures.map((f) =>
-          f.feature === featureKey ? { ...f, enabled } : f,
-        ),
+        prevFeatures.some((f) => f.feature === featureKey)
+          ? prevFeatures.map((f) =>
+              f.feature === featureKey ? { ...f, enabled } : f,
+            )
+          : [...prevFeatures, { id: -1, feature: featureKey, enabled }],
       )
 
       updateWebFeature({

--- a/components/emails/WebCreatedEmail.tsx
+++ b/components/emails/WebCreatedEmail.tsx
@@ -65,7 +65,7 @@ const WebCreatedEmail = ({ webTitle, url }: props) => {
             </Link>
             .
           </Text>
-          <Text>
+          <Text style={paragraph}>
             You can also visit{' '}
             <Link href="https://knowledgebase.resilienceweb.org.uk/">
               our knowledgebase

--- a/components/homepage/join-the-community/JoinTheCommunity.tsx
+++ b/components/homepage/join-the-community/JoinTheCommunity.tsx
@@ -2,14 +2,13 @@ import { FaDiscord } from 'react-icons/fa'
 import Link from 'next/link'
 import SignupForm from '@components/signup-form'
 import { Button } from '@components/ui/button'
-import useIsMobile from '@hooks/application/useIsMobile'
 
 const JoinTheCommunity = () => {
-  const isMobile = useIsMobile()
-
   return (
     <div className="my-12 flex w-full max-w-7xl justify-start">
-      {!isMobile && <CommunityIcon />}
+      <div className="hidden md:block">
+        <CommunityIcon />
+      </div>
       <div className="flex flex-col items-start justify-start px-0 md:px-4">
         <p className="text-base font-medium text-gray-500">
           Want to get involved?

--- a/components/homepage/web-cards/WebCards.tsx
+++ b/components/homepage/web-cards/WebCards.tsx
@@ -11,6 +11,10 @@ const lastOnesOnHomepage = [
   'University of Cambridge',
 ]
 
+// Determines which webs are shown on the homepage. Kept as a shared helper so
+// the hero count reflects exactly what's displayed below.
+export const isWebDisplayedOnHomepage = (web) => Boolean(web.image)
+
 // Function to check if a web was created less than 4 months ago
 const isNewWeb = (createdAt) => {
   if (!createdAt) return false
@@ -30,12 +34,7 @@ const WebCards = ({ webs }) => {
       </h2>
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {webs
-          ?.filter(
-            (web) =>
-              Boolean(web.image) &&
-              web.slug !== 'ctrlshift' &&
-              web.slug !== 'transition-uk',
-          )
+          ?.filter(isWebDisplayedOnHomepage)
           .sort((a, b) => {
             const aIsLast = lastOnesOnHomepage.includes(a.title)
             const bIsLast = lastOnesOnHomepage.includes(b.title)

--- a/components/homepage/web-cards/index.ts
+++ b/components/homepage/web-cards/index.ts
@@ -1,1 +1,1 @@
-export { default } from './WebCards'
+export { default, isWebDisplayedOnHomepage } from './WebCards'

--- a/db/listingEditRepository.ts
+++ b/db/listingEditRepository.ts
@@ -34,6 +34,12 @@ export const getListingEdits = async (listingSlug: string, webSlug?: string) => 
     include: {
       socials: true,
       actions: true,
+      tags: {
+        select: {
+          id: true,
+          label: true,
+        },
+      },
       category: {
         select: {
           id: true,

--- a/hooks/application/useIsMobile.tsx
+++ b/hooks/application/useIsMobile.tsx
@@ -1,7 +1,7 @@
 import useMediaQuerySSR from '@hooks/application/useMediaQuerySSR'
 
 const useIsMobile = () => {
-  const isMobile = useMediaQuerySSR('(max-width: 760px)')
+  const isMobile = useMediaQuerySSR('(max-width: 767px)')
   return isMobile
 }
 

--- a/hooks/listings/useCreateListingEdit.tsx
+++ b/hooks/listings/useCreateListingEdit.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 async function createListingEditRequest(listingData) {
   const formData = new FormData()
   Object.keys(listingData).forEach((key) => {
-    if (key === 'socials' || key === 'actions') {
+    if (key === 'socials' || key === 'actions' || key === 'tags') {
       formData.append(key, JSON.stringify(listingData[key]))
     } else if (key === 'image') {
       if (listingData[key] === null) {
@@ -16,10 +16,13 @@ async function createListingEditRequest(listingData) {
     }
   })
 
-  const response = await fetch(`/api/listings/${listingData.slug}/edit`, {
-    method: 'POST',
-    body: formData,
-  })
+  const response = await fetch(
+    `/api/listings/${listingData.slug}/edit?web=${listingData.webSlug}`,
+    {
+      method: 'POST',
+      body: formData,
+    },
+  )
 
   const data = await response.json()
   const { listing } = data

--- a/hooks/tags/useTags.tsx
+++ b/hooks/tags/useTags.tsx
@@ -10,8 +10,9 @@ async function fetchTagsRequest({ queryKey }) {
   return tags
 }
 
-export default function useTags() {
-  const { selectedWebSlug: webSlug } = useAppContext()
+export default function useTags({ webSlug: webSlugOverride }: { webSlug?: string } = {}) {
+  const { selectedWebSlug } = useAppContext()
+  const webSlug = webSlugOverride ?? selectedWebSlug
   const {
     data: tags,
     isPending,

--- a/hooks/webs/useAllowedWebs.tsx
+++ b/hooks/webs/useAllowedWebs.tsx
@@ -10,7 +10,11 @@ const useAllowedWebs = () => {
     isPending: isLoadingWebs,
     isFetching: isFetchingWebs,
   } = useWebs()
-  const { accessibleWebs, isPending: isLoadingWebAccess } = useMyWebAccess()
+  const {
+    accessibleWebs,
+    isPending: isLoadingWebAccess,
+    isFetching: isFetchingWebAccess,
+  } = useMyWebAccess()
 
   const allowedWebIds = useMemo(() => {
     return accessibleWebs?.map((web) => web.id) ?? []
@@ -33,7 +37,7 @@ const useAllowedWebs = () => {
   return {
     allowedWebs: allAllowedWebs,
     isLoadingWebs: isLoadingWebs || isFetchingWebs,
-    isLoading: isLoadingWebAccess || isFetchingWebs,
+    isLoading: isLoadingWebAccess || isFetchingWebs || isFetchingWebAccess,
   }
 }
 


### PR DESCRIPTION
## Changes

- **Allow adding tags from the public edit listing page** — tags can now be added/edited via the public listing edit flow, with a new tag-edits review step for admins.
- **Fix web creation redirect** — after creating a web, the redirect from `/admin/welcome` to `/admin` now works instead of bouncing back to the welcome page (stale `my-web-access` cache was treated as fresh).
- **Add an empty state for the Web (network) tab** — a new web with no listings now shows a friendly empty state with a "Propose new listing" CTA instead of a blank canvas.
- **Fix display of errors on web creation** — API now returns errors as JSON (`{ error }`) so messages like "A web with the same title or link already exists" display correctly instead of a JSON parse error.
- **Remove unnecessary `useIsMobile` usages** — moved pure show/hide logic to CSS (`hidden md:block`) to avoid hydration/bfcache issues, and aligned the hook's breakpoint to Tailwind's `md` (768px).
- **Minor fixes** — corrected web feature toggling and the web count on the homepage.
