### PR TITLE
Compress network visualization payload with gzip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,9 +207,11 @@ The `Web` model uses soft deletes:
 
 ### Data Compression
 
-Large page data (network visualization) compressed using base64 encoding:
-- See [app/[subdomain]/page.tsx](app/[subdomain]/page.tsx) `getData()` function
-- Reduces initial page load payload
+Large page data (network visualization) is gzip-compressed (then base64-encoded) on the server and stays compressed across the wire, decompressed on the client:
+- Compressed in [app/[subdomain]/page.tsx](app/[subdomain]/page.tsx) `getData()` via `compressJson()`
+- Decompressed in [app/[subdomain]/Web.tsx](app/[subdomain]/Web.tsx) via `decompressJson()`
+- Isomorphic gzip helpers (fflate-based): [helpers/compression.ts](helpers/compression.ts)
+- Reduces the initial page load / RSC payload for webs with many listings
 
 ### Static Generation
 

--- a/app/[subdomain]/Web.tsx
+++ b/app/[subdomain]/Web.tsx
@@ -8,6 +8,7 @@ import '@styles/font-awesome.css'
 import { useQueryState, parseAsArrayOf, parseAsString } from 'nuqs'
 import { useDebounceValue, useLocalStorage } from 'usehooks-ts'
 import { trackWebEvent } from '@helpers/analytics'
+import { decompressJson } from '@helpers/compression'
 import { REMOTE_URL } from '@helpers/config'
 import { isFeatureEnabled, FEATURES } from '@helpers/features'
 import {
@@ -40,11 +41,14 @@ const ListingsMap = dynamic(() => import('@components/listings-map'), {
 
 export const CENTRAL_NODE_ID = 999
 
+type NetworkData = {
+  nodes: ListingNodeType[]
+  edges: any[]
+}
+
 type Props = {
-  data: {
-    nodes: ListingNodeType[]
-    edges: any[]
-  }
+  // gzip+base64 compressed NetworkData, decompressed on the client below.
+  data: string
   events?: any[]
   features: any
   webId: number
@@ -57,7 +61,7 @@ type Props = {
 }
 
 const Web = ({
-  data,
+  data: compressedData,
   events,
   features,
   webId,
@@ -68,6 +72,11 @@ const Web = ({
   webContactEmail,
   webSlug,
 }: Props) => {
+  const data = useMemo<NetworkData | null>(
+    () => (compressedData ? decompressJson<NetworkData>(compressedData) : null),
+    [compressedData],
+  )
+
   const isMobile = useIsMobile()
   const [isVolunteer, setIsVolunteer] = useState(false)
   const defaultTab = isMobile ? 'list' : 'web'

--- a/app/[subdomain]/page.tsx
+++ b/app/[subdomain]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { GraphQLClient } from 'graphql-request'
 import prisma from '@prisma-rw'
+import { compressJson } from '@helpers/compression'
 import { getIconUnicode } from '@helpers/icons'
 import { getAllWebs, getWebBySlug } from '@db/webRepository'
 import Web from './Web'
@@ -25,15 +26,11 @@ export default async function WebPage(props) {
     return notFound()
   }
 
-  const data = (rawData as any).compressed
-    ? JSON.parse(Buffer.from((rawData as any).data, 'base64').toString())
-    : rawData
-
-  const { transformedData, webData } = data
+  const { data, webData } = rawData
 
   return (
     <Web
-      data={transformedData}
+      data={data}
       events={events}
       features={webData.features}
       webId={webData.id}
@@ -77,35 +74,21 @@ export async function generateStaticParams() {
   return subdomains
 }
 
-type DataType =
-  | {
-      transformedData: {
-        nodes: ListingNodeType[]
-        edges: any[]
-      }
-      webData: {
-        title: string
-        description: string
-        published: boolean
-        image: string
-        slug: string
-        features: Record<string, any>
-        contactEmail: string
-      }
-    }
-  | {
-      compressed: true
-      data: string
-      webData: {
-        title: string
-        description: string
-        published: boolean
-        image: string
-        slug: string
-        features: Record<string, any>
-        contactEmail: string
-      }
-    }
+type DataType = {
+  // gzip+base64 compressed network visualization data ({ nodes, edges }).
+  // Kept compressed across the wire and decompressed on the client in Web.tsx.
+  data: string
+  webData: {
+    id: number
+    title: string
+    description: string
+    published: boolean
+    image: string
+    slug: string
+    features: Record<string, any>
+    contactEmail: string
+  }
+}
 
 async function getData({ webSlug }): Promise<DataType> {
   const webData = await prisma.web.findFirst({
@@ -395,16 +378,11 @@ async function getData({ webSlug }): Promise<DataType> {
     })
   }
 
-  const result = {
-    transformedData,
-    // @ts-ignore
-    webData,
-  }
-
-  const compressed = Buffer.from(JSON.stringify(result)).toString('base64')
   return {
-    compressed: true,
-    data: compressed,
+    // Compress only the network visualization data — it's the large payload.
+    // webData is small and is consumed directly for props/metadata.
+    data: compressJson(transformedData),
+    // @ts-ignore
     webData,
   }
 }

--- a/app/_transition/page.tsx
+++ b/app/_transition/page.tsx
@@ -5,6 +5,7 @@ import {
   HydrationBoundary,
 } from '@tanstack/react-query'
 import { groupBy } from 'es-toolkit'
+import { compressJson } from '@helpers/compression'
 import { FEATURES } from '@helpers/features'
 import { generateSlug } from '@helpers/utils'
 import Web, { CENTRAL_NODE_ID } from '../[subdomain]/Web'
@@ -42,7 +43,10 @@ export default async function TransitionPage() {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Web
-        data={data}
+        // Web reads only nodes/edges; compress to match its prop and keep the
+        // payload small across the wire (categories/tags/features are passed
+        // separately via React Query prefetch and the features prop).
+        data={compressJson({ nodes: data.nodes, edges: data.edges })}
         webId={0}
         webName="Transition UK"
         webIsPublished

--- a/helpers/compression.ts
+++ b/helpers/compression.ts
@@ -1,0 +1,48 @@
+import { gzipSync, gunzipSync, strToU8, strFromU8 } from 'fflate'
+
+/**
+ * Isomorphic gzip helpers for shipping large JSON payloads across the
+ * server/client boundary.
+ *
+ * The data is gzip-compressed on the server, base64-encoded so it survives
+ * React Server Component prop serialisation, and stays compressed across the
+ * wire. The client decompresses it synchronously on render. Both `btoa`/`atob`
+ * and fflate work in Node and the browser, so this module is safe to import
+ * from server and client components alike.
+ */
+
+// Largest argument count we feed to String.fromCharCode at once. Converting the
+// whole byte array in a single call risks a stack overflow on large payloads.
+const CHUNK_SIZE = 0x8000
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK_SIZE))
+  }
+  return btoa(binary)
+}
+
+function base64ToBytes(encoded: string): Uint8Array {
+  const binary = atob(encoded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * Gzip-compresses a value and returns a base64 string safe to pass as a prop.
+ */
+export function compressJson(value: unknown): string {
+  return bytesToBase64(gzipSync(strToU8(JSON.stringify(value))))
+}
+
+/**
+ * Reverses {@link compressJson}, decompressing a base64 gzip string back into
+ * its original value.
+ */
+export function decompressJson<T>(encoded: string): T {
+  return JSON.parse(strFromU8(gunzipSync(base64ToBytes(encoded)))) as T
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "diff": "9.0.0",
         "driver.js": "1.4.0",
         "es-toolkit": "1.47.0",
+        "fflate": "0.8.3",
         "graphql": "16.14.0",
         "graphql-request": "7.4.0",
         "input-otp": "1.4.2",
@@ -11556,9 +11557,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -15872,6 +15873,12 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/preact": {
       "version": "10.29.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "diff": "9.0.0",
     "driver.js": "1.4.0",
     "es-toolkit": "1.47.0",
+    "fflate": "0.8.3",
     "graphql": "16.14.0",
     "graphql-request": "7.4.0",
     "input-otp": "1.4.2",


### PR DESCRIPTION
The web network visualization data was being "compressed" with base64 encoding, which actually *inflated* the payload by ~33% and — worse — was decoded server-side before reaching the client, so it never reduced the wire/RSC payload at all.

This replaces it with real gzip compression that stays compressed across the wire and is decompressed synchronously on the client.