### PR TITLE
Improve Sentry: error-only session replay and fix auth logger

### DIFF
--- a/app/auth.ts
+++ b/app/auth.ts
@@ -14,8 +14,15 @@ export const auth = betterAuth({
   logger: {
     level: 'warn',
     log: (level, message, ...args) => {
-      if (level === 'error' || level === 'warn') {
-        Sentry.captureException({ level, message, args })
+      if (level === 'error') {
+        Sentry.captureException(new Error(`[better-auth] ${message}`), {
+          extra: { args },
+        })
+      } else if (level === 'warn') {
+        Sentry.captureMessage(`[better-auth] ${message}`, {
+          level: 'warning',
+          extra: { args },
+        })
       }
     },
   },

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -13,13 +13,14 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  replaysOnErrorSampleRate: 0,
+  replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 0,
 
   integrations: [
     Sentry.feedbackIntegration({
       colorScheme: 'system',
     }),
+    Sentry.replayIntegration(),
   ],
 })
 


### PR DESCRIPTION
## Summary

Two Sentry improvements focused on better issue diagnosis:

- **Enable error-only Session Replay** — sets `replaysOnErrorSampleRate: 1.0` (session sampling stays at `0`) and adds the required `Sentry.replayIntegration()`. A replay is now captured **only when an error fires**, giving us a video-like reproduction of the failing interaction while keeping replay-quota usage low (consumed at error rate, not traffic rate). This is safe on the free tier — if the monthly replay allowance is exhausted, recording simply pauses with no charge.
- **Fix the better-auth logger** — it previously called `Sentry.captureException({ level, message, args })` with a plain object. Sentry recorded that as a single mis-grouped *"Non-Error exception captured"* issue, and it fired on `warn` too. Errors now wrap a real `Error` (so they group by message); warnings use `captureMessage` at warning level. Original args are preserved in `extra`.