### PR TITLE
Fix slow DB queries in /api/categories and /api/tags

### DIFF
--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -6,16 +6,33 @@ import prisma from '@prisma-rw'
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
-    const web = searchParams.get('web')
+    const webSlug = searchParams.get('web')
+
+    if (!webSlug) {
+      return Response.json({ data: [] })
+    }
+
+    // Resolve the web up front so the listing count below can be scoped to it.
+    // Filtering the count by `webId` is what keeps the query fast: without it
+    // Postgres aggregates the entire listing_placements table (every web) on
+    // every request, then throws away all but this web's categories.
+    const web = await prisma.web.findFirst({
+      where: {
+        slug: webSlug,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+      },
+    })
+
+    if (!web) {
+      return Response.json({ data: [] })
+    }
 
     const categories = await prisma.category.findMany({
       where: {
-        web: {
-          slug: {
-            equals: web,
-          },
-          deletedAt: null,
-        },
+        webId: web.id,
       },
       select: {
         id: true,
@@ -25,9 +42,15 @@ export async function GET(request: NextRequest) {
         color: true,
         icon: true,
         webId: true,
+        // A category only ever belongs to one web, so scoping by webId does not
+        // change the count - it just lets the aggregate use the webId index
         _count: {
           select: {
-            listings: true,
+            listings: {
+              where: {
+                webId: web.id,
+              },
+            },
           },
         },
       },

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -6,7 +6,29 @@ import prisma from '@prisma-rw'
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
-    const web = searchParams.get('web')
+    const webSlug = searchParams.get('web')
+
+    if (!webSlug) {
+      return Response.json({ data: [] })
+    }
+
+    // Resolve the web up front so the listing count below can be scoped to it.
+    // Filtering the count by `webId` is what keeps the query fast: without it
+    // Postgres joins the whole listing_placements table to the whole
+    // placement/tag join table and groups that, on every request.
+    const web = await prisma.web.findFirst({
+      where: {
+        slug: webSlug,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+      },
+    })
+
+    if (!web) {
+      return Response.json({ data: [] })
+    }
 
     const tags = await prisma.tag.findMany({
       select: {
@@ -14,19 +36,20 @@ export async function GET(request: NextRequest) {
         label: true,
         webId: true,
         listingEditId: true,
+        // A tag only ever belongs to one web, so scoping by webId does not
+        // change the count - it just lets the aggregate use the webId index
         _count: {
           select: {
-            listings: true,
+            listings: {
+              where: {
+                webId: web.id,
+              },
+            },
           },
         },
       },
       where: {
-        web: {
-          slug: {
-            equals: web,
-          },
-          deletedAt: null,
-        },
+        webId: web.id,
       },
       orderBy: [
         {

--- a/prisma/migrations/20260726120000_add_listing_placements_web_category_index/migration.sql
+++ b/prisma/migrations/20260726120000_add_listing_placements_web_category_index/migration.sql
@@ -1,0 +1,4 @@
+-- Lets the per-web category listing counts in /api/categories run as an
+-- index-only scan instead of an index scan plus heap fetches
+-- CreateIndex
+CREATE INDEX "listing_placements_web_id_category_id_idx" ON "listing_placements"("web_id", "category_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,6 +199,9 @@ model ListingPlacement {
   @@unique([listingId, webId], name: "listingPlacementPair")
   @@unique([webId, slug], name: "webSlug")
   @@index([webId])
+  // Serves the per-web category listing counts in /api/categories as an
+  // index-only scan
+  @@index([webId, categoryId])
   @@map("listing_placements")
 }
 


### PR DESCRIPTION
Sentry flagged slow queries on both endpoints. Prisma compiles a relation `_count` into an **unscoped** derived table — the `WHERE 1=1` in the generated SQL:

```sql
LEFT JOIN (SELECT category_id, COUNT(*) FROM listing_placements WHERE 1=1 GROUP BY category_id)
```

So every request aggregated *all* of `listing_placements` across *every* web, then joined that to the one web's ~20 categories and threw the rest away. Cost scaled with total platform size rather than the web being viewed. Tags was worse — it joined the whole `listing_placements` table to the whole `_ListingPlacementToTag` table and grouped that.

Both endpoints are fetched on every public web page view, hence the volume.

## Changes

- Resolve the web by slug first, then use a *filtered* relation count so `web_id` lands inside the aggregate.
- Early-return `[]` when the `web` param is missing instead of round-tripping to the DB to match nothing.
- Add `@@index([webId, categoryId])` on `ListingPlacement`, which makes the categories aggregate an `Index Only Scan`. Tags already had what it needed.

Counts are unchanged: a category or tag belongs to exactly one web, so scoping is semantically a no-op. Response shape (`_count.listings`) is identical, so the admin lists, the `CategoryForm` delete guard and `useTagsPublic` all keep working.

## Steps to test

1. Load a web's public page and confirm category/tag filters populate as before.
2. In admin, check the listing counts on the categories and tags lists match what they were.
3. Confirm a category with listings still can't be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)