### PR TITLE
Filter browser-extension errors out of Sentry

### DIFF
--- a/helpers/__tests__/sentry.test.ts
+++ b/helpers/__tests__/sentry.test.ts
@@ -1,0 +1,85 @@
+import * as Sentry from '@sentry/nextjs'
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { BROWSER_EXTENSION_ERRORS, BROWSER_EXTENSION_URLS } from '../sentry'
+
+describe('Sentry browser-extension filtering', () => {
+  let reported: string[] = []
+
+  beforeAll(() => {
+    Sentry.init({
+      dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+      ignoreErrors: BROWSER_EXTENSION_ERRORS,
+      denyUrls: BROWSER_EXTENSION_URLS,
+      beforeSend: (event) => {
+        const value = event.exception?.values?.[0]?.value
+        if (value) reported.push(value)
+        return null
+      },
+    })
+  })
+
+  beforeEach(() => {
+    reported = []
+  })
+
+  const capture = async (error: Error) => {
+    Sentry.captureException(error)
+    await Sentry.flush(2000)
+  }
+
+  it('drops extension messaging errors', async () => {
+    await capture(
+      new Error('Invalid call to runtime.sendMessage(). Tab not found.'),
+    )
+
+    expect(reported).toEqual([])
+  })
+
+  it('drops extension content script errors', async () => {
+    await capture(
+      new TypeError(
+        "undefined is not an object (evaluating 'contentScriptData.init_ts')",
+      ),
+    )
+
+    expect(reported).toEqual([])
+  })
+
+  it('drops errors thrown after an extension context is torn down', async () => {
+    await capture(new Error('Extension context invalidated.'))
+
+    expect(reported).toEqual([])
+  })
+
+  it('still reports application errors', async () => {
+    await capture(new Error('Failed to fetch listings for web: 504'))
+
+    expect(reported).toEqual(['Failed to fetch listings for web: 504'])
+  })
+
+  it('still reports network and API failures', async () => {
+    await capture(new Error('AxiosError: Request failed with status code 403'))
+
+    expect(reported).toEqual([
+      'AxiosError: Request failed with status code 403',
+    ])
+  })
+})
+
+describe('BROWSER_EXTENSION_URLS', () => {
+  const matches = (url: string) =>
+    BROWSER_EXTENSION_URLS.some((it) => it.test(url))
+
+  it('matches scripts served from extension protocols', () => {
+    expect(matches('chrome-extension://abcdef/contentScript.js')).toBe(true)
+    expect(matches('moz-extension://abcdef/contentScript.js')).toBe(true)
+    expect(matches('safari-web-extension://abcdef/contentScript.js')).toBe(true)
+  })
+
+  it('leaves our own bundles reportable', () => {
+    expect(
+      matches('https://resilienceweb.org.uk/_next/static/chunks/main.js'),
+    ).toBe(false)
+    expect(matches('webkit-masked-url://hidden/')).toBe(false)
+  })
+})

--- a/helpers/sentry.ts
+++ b/helpers/sentry.ts
@@ -1,0 +1,15 @@
+export const BROWSER_EXTENSION_ERRORS = [
+  /Invalid call to runtime\.sendMessage\(\)/i,
+  /Extension context invalidated/i,
+  /contentScriptData/,
+]
+
+// webkit-masked-url:// is deliberately not denied — Safari also masks
+// first-party bundle URLs, so denying it would swallow real errors.
+export const BROWSER_EXTENSION_URLS = [
+  /^chrome-extension:\/\//,
+  /^chrome-untrusted:\/\//,
+  /^moz-extension:\/\//,
+  /^safari-extension:\/\//,
+  /^safari-web-extension:\/\//,
+]

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,10 +2,18 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import * as Sentry from '@sentry/nextjs'
+import {
+  BROWSER_EXTENSION_ERRORS,
+  BROWSER_EXTENSION_URLS,
+} from '@helpers/sentry'
 
 Sentry.init({
   dsn: 'https://a205584b48c84a7fbfcd3632479d33f7@o4505069644611584.ingest.sentry.io/4505069646643200',
   enabled: process.env.NODE_ENV === 'production',
+
+  // Drop noise injected by browser extensions rather than our own code
+  ignoreErrors: BROWSER_EXTENSION_ERRORS,
+  denyUrls: BROWSER_EXTENSION_URLS,
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,


### PR DESCRIPTION
## Background

Browser extensions inject content scripts into our pages, and when those scripts throw, the errors land in our Sentry project as noise — no first-party code in the stacktrace (often no stacktrace at all), 0 users actually impacted, but they crowd out real issues. We can't fix code we don't ship, so the fix is to stop ingesting it.

## Solution

Added [helpers/sentry.ts](../blob/filter-browser-extension-sentry-errors/helpers/sentry.ts) holding two pattern lists, wired into the client-side `Sentry.init` in `instrumentation-client.ts`:

- **`ignoreErrors`** matches known extension-origin error messages (`Invalid call to runtime.sendMessage()`, `Extension context invalidated`, `contentScriptData`) — this is what catches events that arrive with no usable stacktrace.
- **`denyUrls`** covers the extension protocols (`chrome-extension://`, `moz-extension://`, `safari-web-extension://`, …) so future variants that *do* arrive with extension frames get dropped without another PR.

The node/edge inits in `instrumentation.ts` are deliberately untouched — extensions can only inject into client pages.

Two judgement calls worth flagging:

1. **`webkit-masked-url://` is deliberately *not* in `denyUrls`.** Safari also masks *our own* bundle URLs in some contexts, so denying that scheme risks silently swallowing real errors. There's a test pinning `webkit-masked-url://hidden/` as reportable.
2. **Patterns are scoped tightly to extension-origin messages.** Generic high-volume noise like `TypeError: Load failed` *can* be ours — out of scope here.

## Testing

The tests exercise the real `@sentry/nextjs` SDK rather than asserting on the regexes in isolation, so they verify the `Sentry.init` wiring actually drops these events:

- `npx vitest run helpers/__tests__/sentry.test.ts` — 7 tests. Extension-origin errors are dropped; app errors (a 504 fetch failure, an Axios 403) still report as a positive control confirming the harness captures events at all.
- Full vitest run: the 4 failures in `lib/import/__tests__/mapper.test.ts` are pre-existing on `main` (verified via `git stash`), unrelated to this change.
- `eslint`, `prettier`, and `tsc` clean on the changed files.

No user-visible change — this only affects what gets reported to Sentry.
