### PR TITLE
fix: check web-scoped rights on every mutating API route

### DIFF
--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,22 +1,49 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
+
+/** The web a category belongs to is what the caller needs rights over. */
+async function findCategoryWebId(categoryId: number) {
+  if (!Number.isInteger(categoryId)) {
+    return null
+  }
+  const category = await prisma.category.findUnique({
+    where: { id: categoryId },
+    select: { webId: true },
+  })
+  return category?.webId ?? null
+}
 
 export async function PATCH(
   request: NextRequest,
   props: { params: Promise<{ id: string }> },
 ) {
   const params = await props.params
-  const categoryId = params.id
+  const categoryId = Number(params.id)
   const body = await request.json()
 
+  const webId = await findCategoryWebId(categoryId)
+  if (webId === null) {
+    return Response.json({ error: 'Category not found' }, { status: 404 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
+
   try {
+    // Enumerated, not spread: `data: body` would let the caller move the
+    // category to a web they have no rights over.
     const category = await prisma.category.update({
       where: {
-        id: Number(categoryId),
+        id: categoryId,
       },
-      data: body,
+      data: {
+        ...(body.label !== undefined ? { label: body.label } : {}),
+        ...(body.color !== undefined ? { color: body.color } : {}),
+        ...(body.icon !== undefined ? { icon: body.icon } : {}),
+      },
       include: {
         web: {
           select: {
@@ -39,16 +66,24 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   props: { params: Promise<{ id: string }> },
 ) {
   const params = await props.params
-  const categoryId = params.id
+  const categoryId = Number(params.id)
+
+  const webId = await findCategoryWebId(categoryId)
+  if (webId === null) {
+    return Response.json({ error: 'Category not found' }, { status: 404 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
 
   try {
     const category = await prisma.category.delete({
       where: {
-        id: Number(categoryId),
+        id: categoryId,
       },
     })
 

--- a/app/api/categories/__tests__/route.integration.test.ts
+++ b/app/api/categories/__tests__/route.integration.test.ts
@@ -2,12 +2,20 @@ import {
   createCategory,
   createListing,
   createTag,
+  createUser,
+  createUserWithWebAccess,
   createWeb,
 } from '@/test/factories'
-import { request } from '@/test/http'
+import { params, request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
 import { describe, expect, it } from 'vitest'
 import prisma from '@prisma-rw'
 import { GET as getTags } from '../../tags/route.ts'
+import {
+  DELETE as deleteCategory,
+  PATCH as patchCategory,
+} from '../[id]/route.ts'
 import { GET as getCategories, POST as postCategory } from '../route.ts'
 
 const json = async (response: Response) =>
@@ -78,19 +86,21 @@ describe('GET /api/categories', () => {
   })
 })
 
+const createRequest = (body: Record<string, unknown>) =>
+  request('/api/categories', { method: 'POST', body })
+
 describe('POST /api/categories', () => {
   it('creates a category on the web', async () => {
     const web = await createWeb({ slug: 'bristol' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
 
     const response = await postCategory(
-      request('/api/categories', {
-        method: 'POST',
-        body: {
-          label: 'Housing',
-          color: 'cb6ce6',
-          icon: 'Home',
-          webId: web.id,
-        },
+      createRequest({
+        label: 'Housing',
+        color: 'cb6ce6',
+        icon: 'Home',
+        webId: web.id,
       }),
     )
 
@@ -104,16 +114,188 @@ describe('POST /api/categories', () => {
   it('rejects a duplicate label within the same web', async () => {
     const web = await createWeb({ slug: 'bristol' })
     await createCategory(web.id, { label: 'Housing' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
 
     const response = await postCategory(
-      request('/api/categories', {
-        method: 'POST',
-        body: { label: 'Housing', webId: web.id },
-      }),
+      createRequest({ label: 'Housing', webId: web.id }),
     )
 
     expect(response.status).toBe(500)
     expect(await prisma.category.count({ where: { webId: web.id } })).toBe(1)
+  })
+
+  it('rejects an anonymous caller', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await postCategory(
+      createRequest({ label: 'Housing', webId: web.id }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.category.count()).toBe(0)
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await postCategory(
+      createRequest({ label: 'Housing', webId: web.id }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.category.count()).toBe(0)
+  })
+
+  it('allows a global admin without web access', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await postCategory(
+      createRequest({ label: 'Housing', webId: web.id }),
+    )
+
+    expect(response.status).toBe(200)
+  })
+
+  it('ignores a webId the caller smuggles alongside extra relation writes', async () => {
+    // `data: body` made `listings` a way past the check.
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const theirListing = await createListing(otherWeb.id)
+    const theirPlacement = theirListing.placements[0]
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await postCategory(
+      createRequest({
+        label: 'Housing',
+        webId: web.id,
+        listings: { connect: [{ id: theirPlacement?.id }] },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(
+      (
+        await prisma.listingPlacement.findUnique({
+          where: { id: theirPlacement?.id },
+        })
+      )?.categoryId,
+    ).toBeNull()
+  })
+})
+
+describe('PATCH /api/categories/[id]', () => {
+  it('rejects an editor of a different web and leaves the label alone', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const category = await createCategory(web.id, { label: 'Housing' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await patchCategory(
+      request(`/api/categories/${category.id}`, {
+        method: 'PATCH',
+        body: { label: 'Hijacked' },
+      }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(
+      (await prisma.category.findUnique({ where: { id: category.id } }))?.label,
+    ).toBe('Housing')
+  })
+
+  it('lets an editor of the web rename it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const category = await createCategory(web.id, { label: 'Housing' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await patchCategory(
+      request(`/api/categories/${category.id}`, {
+        method: 'PATCH',
+        body: { label: 'Homes', color: 'ff5757' },
+      }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(
+      (await prisma.category.findUnique({ where: { id: category.id } }))?.label,
+    ).toBe('Homes')
+  })
+
+  it('cannot be used to move a category into another web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const category = await createCategory(web.id, { label: 'Housing' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    await patchCategory(
+      request(`/api/categories/${category.id}`, {
+        method: 'PATCH',
+        body: { label: 'Housing', webId: otherWeb.id },
+      }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(
+      (await prisma.category.findUnique({ where: { id: category.id } }))?.webId,
+    ).toBe(web.id)
+  })
+})
+
+describe('DELETE /api/categories/[id]', () => {
+  it('rejects an anonymous caller and keeps the category', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const category = await createCategory(web.id)
+
+    const response = await deleteCategory(
+      request(`/api/categories/${category.id}`, { method: 'DELETE' }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.category.count()).toBe(1)
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const category = await createCategory(web.id)
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await deleteCategory(
+      request(`/api/categories/${category.id}`, { method: 'DELETE' }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.category.count()).toBe(1)
+  })
+
+  it('lets an editor of the web delete it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const category = await createCategory(web.id)
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await deleteCategory(
+      request(`/api/categories/${category.id}`, { method: 'DELETE' }),
+      params({ id: String(category.id) }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await prisma.category.count()).toBe(0)
   })
 })
 

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 
@@ -73,9 +74,25 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const body = await request.json()
+  const webId = Number(body?.webId)
+
+  if (!Number.isInteger(webId)) {
+    return Response.json({ error: 'webId is required' }, { status: 400 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
+
   try {
+    // Enumerated, not spread: `data: body` would let the caller set `webId`
+    // past the check above, or reach other webs through `listings`.
     const category = await prisma.category.create({
-      data: body,
+      data: {
+        webId,
+        label: body.label,
+        ...(body.color ? { color: body.color } : {}),
+        ...(body.icon ? { icon: body.icon } : {}),
+      },
       include: {
         web: {
           select: {

--- a/app/api/listing/[id]/feature/route.ts
+++ b/app/api/listing/[id]/feature/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 
@@ -18,6 +19,9 @@ export async function PATCH(
         { status: 400 },
       )
     }
+
+    const denied = await requireWebEditor(request, Number(webId))
+    if (denied) return denied
 
     const featuredUntil = new Date()
     featuredUntil.setDate(featuredUntil.getDate() + 7)

--- a/app/api/listing/[id]/unfeature/route.ts
+++ b/app/api/listing/[id]/unfeature/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 
@@ -18,6 +19,9 @@ export async function PATCH(
         { status: 400 },
       )
     }
+
+    const denied = await requireWebEditor(request, Number(webId))
+    if (denied) return denied
 
     const placement = await prisma.listingPlacement.update({
       where: {

--- a/app/api/listing/__tests__/feature-route.integration.test.ts
+++ b/app/api/listing/__tests__/feature-route.integration.test.ts
@@ -1,0 +1,112 @@
+import {
+  createListing,
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { params, request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { PATCH as feature } from '../[id]/feature/route.ts'
+import { PATCH as unfeature } from '../[id]/unfeature/route.ts'
+
+const call = (
+  handler: typeof feature,
+  path: string,
+  listingId: number,
+  webId: number,
+) =>
+  handler(
+    request(`/api/listing/${listingId}/${path}`, {
+      method: 'PATCH',
+      body: { webId },
+    }),
+    params({ id: String(listingId) }),
+  )
+
+const featuredOf = async (listingId: number, webId: number) =>
+  (
+    await prisma.listingPlacement.findUnique({
+      where: { listingPlacementPair: { listingId, webId } },
+    })
+  )?.featured
+
+describe('PATCH /api/listing/[id]/feature', () => {
+  it('rejects an anonymous caller and leaves the placement unfeatured', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id)
+
+    const response = await call(feature, 'feature', listing.id, web.id)
+
+    expect(response.status).toBe(403)
+    expect(await featuredOf(listing.id, web.id)).toBeNull()
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id)
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await call(feature, 'feature', listing.id, web.id)
+
+    expect(response.status).toBe(403)
+    expect(await featuredOf(listing.id, web.id)).toBeNull()
+  })
+
+  it('lets an editor of the web feature it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id)
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await call(feature, 'feature', listing.id, web.id)
+
+    expect(response.status).toBe(200)
+    expect(await featuredOf(listing.id, web.id)).toBeInstanceOf(Date)
+  })
+
+  it('lets a global admin feature a listing in any web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id)
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    expect((await call(feature, 'feature', listing.id, web.id)).status).toBe(
+      200,
+    )
+  })
+})
+
+describe('PATCH /api/listing/[id]/unfeature', () => {
+  it('rejects an editor of a different web and keeps it featured', async () => {
+    const featuredUntil = new Date('2099-01-01')
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, { featured: featuredUntil })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await call(unfeature, 'unfeature', listing.id, web.id)
+
+    expect(response.status).toBe(403)
+    expect(await featuredOf(listing.id, web.id)).toEqual(featuredUntil)
+  })
+
+  it('lets an editor of the web unfeature it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      featured: new Date('2099-01-01'),
+    })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await call(unfeature, 'unfeature', listing.id, web.id)
+
+    expect(response.status).toBe(200)
+    expect(await featuredOf(listing.id, web.id)).toBeNull()
+  })
+})

--- a/app/api/listings/[slug]/edit/route.ts
+++ b/app/api/listings/[slug]/edit/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -42,6 +43,11 @@ export async function GET(
   }
 }
 
+/**
+ * Deliberately open to any signed-in visitor: proposing an edit publishes
+ * nothing. It lands in `ListingEdit` and reaches the listing only once an editor
+ * approves it, which is where the web-scoped check lives.
+ */
 export async function POST(request, props) {
   const params = await props.params
   try {
@@ -226,6 +232,7 @@ export async function POST(request, props) {
   }
 }
 
+/** Rejecting an edit is the mirror of approving it, so it takes the same rights. */
 export async function DELETE(request, props) {
   const params = await props.params
   try {
@@ -249,6 +256,9 @@ export async function DELETE(request, props) {
     if (!placement) {
       return new Response('Listing not found', { status: 404 })
     }
+
+    const denied = await requireWebEditor(request, placement.webId)
+    if (denied) return denied
 
     const listingEdit = await prisma.listingEdit.findFirst({
       where: {

--- a/app/api/listings/[slug]/route.ts
+++ b/app/api/listings/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -109,10 +110,59 @@ export async function GET(
   }
 }
 
+/**
+ * `prisma.listing.update` is keyed on the listing alone, so the placement has to
+ * be established before the caller can be checked against anything.
+ */
+async function resolvePlacementWebId(
+  listingId: number,
+  requestedWebId: number | undefined,
+) {
+  const existing = await prisma.listing.findUnique({
+    where: { id: listingId },
+    select: { placements: { select: { webId: true } } },
+  })
+
+  if (!existing) {
+    return { error: new Response('Listing not found', { status: 404 }) }
+  }
+
+  if (requestedWebId === undefined) {
+    if (existing.placements.length !== 1) {
+      return {
+        error: new Response(
+          'Listing exists in multiple webs; webId is required to disambiguate',
+          { status: 400 },
+        ),
+      }
+    }
+    return { webId: existing.placements[0].webId }
+  }
+
+  if (!existing.placements.some((p) => p.webId === requestedWebId)) {
+    return {
+      error: new Response('Listing not found in this web', { status: 404 }),
+    }
+  }
+
+  return { webId: requestedWebId }
+}
+
 export async function PUT(request) {
   try {
     const formData = await request.formData()
     const listingId = formData.get('id')
+
+    const formWebId = formData.get('webId')
+    const { webId: placementWebId, error } = await resolvePlacementWebId(
+      Number(listingId),
+      formWebId ? Number(formWebId) : undefined,
+    )
+    if (error) return error
+
+    const denied = await requireWebEditor(request, placementWebId)
+    if (denied) return denied
+
     const tags = formData.get('tags')
     const removedTags = formData.get('removedTags')
     const relations = formData.get('relations')
@@ -265,28 +315,6 @@ export async function PUT(request) {
       newData.image = null
     }
 
-    const formWebId = formData.get('webId')
-    let placementWebId: number | undefined = formWebId
-      ? Number(formWebId)
-      : undefined
-
-    if (placementWebId === undefined) {
-      const existing = await prisma.listing.findUnique({
-        where: { id: Number(listingId) },
-        select: { placements: { select: { webId: true }, take: 2 } },
-      })
-      if (!existing) {
-        return new Response('Listing not found', { status: 404 })
-      }
-      if (existing.placements.length !== 1) {
-        return new Response(
-          'Listing exists in multiple webs; webId is required to disambiguate',
-          { status: 400 },
-        )
-      }
-      placementWebId = existing.placements[0].webId
-    }
-
     const placementUpdate: Prisma.ListingPlacementUpdateInput = {
       slug: slug as string,
       featured: featuredDate,
@@ -431,6 +459,13 @@ export async function DELETE(
   try {
     const slug = params.slug
     const { webId } = await request.json()
+
+    if (!Number.isInteger(webId)) {
+      return Response.json({ error: 'webId is required' }, { status: 400 })
+    }
+
+    const denied = await requireWebEditor(request, webId)
+    if (denied) return denied
 
     const placement = await prisma.listingPlacement.findUnique({
       where: { webSlug: { webId, slug } },

--- a/app/api/listings/__tests__/edit-route.integration.test.ts
+++ b/app/api/listings/__tests__/edit-route.integration.test.ts
@@ -1,0 +1,83 @@
+import {
+  createListing,
+  createListingEdit,
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { params, request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { DELETE } from '../[slug]/edit/route.ts'
+
+const rejectEdit = (slug: string, webSlug: string) =>
+  DELETE(
+    request(`/api/listings/${slug}/edit?web=${webSlug}`, { method: 'DELETE' }),
+    params({ slug }),
+  )
+
+describe('DELETE /api/listings/[slug]/edit', () => {
+  const setup = async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, { slug: 'food-hub' })
+    const proposer = await createUser()
+    const edit = await createListingEdit(web.id, listing.id, proposer.id)
+    return { web, listing, proposer, edit }
+  }
+
+  it('rejects an anonymous caller and keeps the edit', async () => {
+    await setup()
+
+    const response = await rejectEdit('food-hub', 'bristol')
+
+    expect(response.status).toBe(401)
+    expect(await prisma.listingEdit.count()).toBe(1)
+  })
+
+  it('rejects a signed-in stranger and keeps the edit', async () => {
+    await setup()
+    const stranger = await createUser()
+    signInAs({ id: stranger.id, email: stranger.email })
+
+    const response = await rejectEdit('food-hub', 'bristol')
+
+    expect(response.status).toBe(403)
+    expect(await prisma.listingEdit.count()).toBe(1)
+  })
+
+  it('rejects an editor of a different web', async () => {
+    await setup()
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await rejectEdit('food-hub', 'bristol')
+
+    expect(response.status).toBe(403)
+    expect(await prisma.listingEdit.count()).toBe(1)
+  })
+
+  it('lets an editor of the web reject it', async () => {
+    const { web } = await setup()
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await rejectEdit('food-hub', 'bristol')
+
+    expect(response.status).toBe(200)
+    expect(await prisma.listingEdit.count()).toBe(0)
+  })
+
+  it('lets a global admin reject it', async () => {
+    await setup()
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await rejectEdit('food-hub', 'bristol')
+
+    expect(response.status).toBe(200)
+    expect(await prisma.listingEdit.count()).toBe(0)
+  })
+})

--- a/app/api/listings/__tests__/route.integration.test.ts
+++ b/app/api/listings/__tests__/route.integration.test.ts
@@ -1,0 +1,175 @@
+import {
+  createCategory,
+  createListing,
+  createTag,
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { POST } from '../route.ts'
+
+const newListingForm = (fields: Record<string, string> = {}) => {
+  const form = new FormData()
+  form.set('title', 'Food Hub')
+  form.set('slug', 'food-hub')
+  form.set('description', 'A food hub')
+  form.set('email', '')
+  form.set('website', '')
+  form.set('tags', '')
+  form.set('relations', '')
+  form.set('seekingVolunteers', 'false')
+  Object.entries(fields).forEach(([key, value]) => form.set(key, value))
+  return form
+}
+
+const post = (form: FormData) =>
+  POST(request('/api/listings', { method: 'POST', body: form }))
+
+describe('POST /api/listings', () => {
+  it('accepts an anonymous proposal', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await post(
+      newListingForm({ webId: String(web.id), pending: 'true' }),
+    )
+
+    expect(response.status).toBe(201)
+    expect((await prisma.listing.findFirst())?.pending).toBe(true)
+  })
+
+  it('forces an anonymous listing to be pending, whatever the form says', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await post(
+      newListingForm({ webId: String(web.id), pending: 'false' }),
+    )
+
+    expect(response.status).toBe(201)
+    expect((await prisma.listing.findFirst())?.pending).toBe(true)
+  })
+
+  it('forces a signed-in stranger to be pending', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const stranger = await createUser()
+    signInAs({ id: stranger.id, email: stranger.email })
+
+    await post(newListingForm({ webId: String(web.id), pending: 'false' }))
+
+    expect((await prisma.listing.findFirst())?.pending).toBe(true)
+  })
+
+  it('lets an editor of the web publish straight away', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await post(
+      newListingForm({ webId: String(web.id), pending: 'false' }),
+    )
+
+    expect(response.status).toBe(201)
+    expect((await prisma.listing.findFirst())?.pending).toBe(false)
+  })
+
+  it('records the signed-in user as proposer, not whoever the form names', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const stranger = await createUser()
+    const someoneElse = await createUser()
+    signInAs({ id: stranger.id, email: stranger.email })
+
+    await post(
+      newListingForm({
+        webId: String(web.id),
+        pending: 'true',
+        proposerId: someoneElse.id,
+      }),
+    )
+
+    expect((await prisma.listing.findFirst())?.proposerId).toBe(stranger.id)
+  })
+
+  it('ignores a featured date on a proposal', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    await post(
+      newListingForm({
+        webId: String(web.id),
+        pending: 'false',
+        featured: new Date('2026-01-01').toISOString(),
+      }),
+    )
+
+    const placement = await prisma.listingPlacement.findFirst()
+    expect(placement?.featured).toBeNull()
+  })
+
+  it('ignores a category belonging to another web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const theirCategory = await createCategory(otherWeb.id)
+
+    await post(
+      newListingForm({
+        webId: String(web.id),
+        pending: 'true',
+        category: String(theirCategory.id),
+      }),
+    )
+
+    expect((await prisma.listingPlacement.findFirst())?.categoryId).toBeNull()
+  })
+
+  it('ignores tags belonging to another web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const theirTag = await createTag(otherWeb.id)
+
+    await post(
+      newListingForm({
+        webId: String(web.id),
+        pending: 'true',
+        tags: String(theirTag.id),
+      }),
+    )
+
+    const placement = await prisma.listingPlacement.findFirst({
+      include: { tags: true },
+    })
+    expect(placement?.tags).toEqual([])
+  })
+
+  it('does not let a proposal relate itself to an existing listing', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const existing = await createListing(web.id)
+
+    await post(
+      newListingForm({
+        webId: String(web.id),
+        pending: 'true',
+        relations: String(existing.id),
+      }),
+    )
+
+    const related = await prisma.listing.findUnique({
+      where: { id: existing.id },
+      include: { relations: true },
+    })
+    expect(related?.relations).toEqual([])
+  })
+
+  it('404s for a soft-deleted web instead of creating an orphan', async () => {
+    const web = await createWeb({ slug: 'bristol', deletedAt: new Date() })
+
+    const response = await post(
+      newListingForm({ webId: String(web.id), pending: 'true' }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(await prisma.listing.count()).toBe(0)
+  })
+})

--- a/app/api/listings/__tests__/slug-route.integration.test.ts
+++ b/app/api/listings/__tests__/slug-route.integration.test.ts
@@ -1,0 +1,206 @@
+import {
+  createListing,
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { params, request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { DELETE, PUT } from '../[slug]/route.ts'
+
+const listingForm = (fields: Record<string, string> = {}) => {
+  const form = new FormData()
+  form.set('title', 'Food Hub')
+  form.set('slug', 'food-hub')
+  form.set('website', '')
+  form.set('description', 'A food hub')
+  form.set('email', '')
+  form.set('tags', '')
+  form.set('removedTags', '')
+  form.set('relations', '')
+  form.set('removedRelations', '')
+  form.set('seekingVolunteers', 'false')
+  form.set('inactive', 'false')
+  form.set('noPhysicalLocation', 'false')
+  form.set('removeLocation', 'false')
+  Object.entries(fields).forEach(([key, value]) => form.set(key, value))
+  return form
+}
+
+// PUT identifies the listing from the form's `id`, not from the URL segment,
+// so it takes no params.
+const put = (slug: string, form: FormData) =>
+  PUT(request(`/api/listings/${slug}`, { method: 'PUT', body: form }))
+
+const del = (slug: string, webId: number) =>
+  DELETE(
+    request(`/api/listings/${slug}`, { method: 'DELETE', body: { webId } }),
+    params({ slug }),
+  )
+
+describe('PUT /api/listings/[slug]', () => {
+  it('rejects an anonymous caller and leaves the listing alone', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+
+    const response = await put(
+      'food-hub',
+      listingForm({ id: String(listing.id), webId: String(web.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(
+      (await prisma.listing.findUnique({ where: { id: listing.id } }))?.title,
+    ).toBe('Original')
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await put(
+      'food-hub',
+      listingForm({ id: String(listing.id), webId: String(web.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(
+      (await prisma.listing.findUnique({ where: { id: listing.id } }))?.title,
+    ).toBe('Original')
+  })
+
+  it('rejects a webId the caller owns when the listing is not in that web', async () => {
+    // `prisma.listing.update` is keyed on the listing alone, so passing a web
+    // you *can* edit was a way to reach a listing you cannot.
+    const web = await createWeb({ slug: 'bristol' })
+    const theirListing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+    const myWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(myWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await put(
+      'food-hub',
+      listingForm({ id: String(theirListing.id), webId: String(myWeb.id) }),
+    )
+
+    expect(response.status).toBe(404)
+    expect(
+      (await prisma.listing.findUnique({ where: { id: theirListing.id } }))
+        ?.title,
+    ).toBe('Original')
+  })
+
+  it('lets an editor of the web update the listing', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await put(
+      'food-hub',
+      listingForm({
+        id: String(listing.id),
+        webId: String(web.id),
+        title: 'Bristol Food Hub',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(
+      (await prisma.listing.findUnique({ where: { id: listing.id } }))?.title,
+    ).toBe('Bristol Food Hub')
+  })
+
+  it('lets a global admin update a listing in any web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await put(
+      'food-hub',
+      listingForm({
+        id: String(listing.id),
+        webId: String(web.id),
+        title: 'Renamed',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+  })
+
+  it('resolves the web itself when the form omits webId', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id, {
+      title: 'Original',
+      slug: 'food-hub',
+    })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await put(
+      'food-hub',
+      listingForm({ id: String(listing.id) }),
+    )
+
+    expect(response.status).toBe(200)
+  })
+})
+
+describe('DELETE /api/listings/[slug]', () => {
+  it('rejects an anonymous caller and keeps the listing', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    await createListing(web.id, { slug: 'food-hub' })
+
+    const response = await del('food-hub', web.id)
+
+    expect(response.status).toBe(403)
+    expect(await prisma.listing.count()).toBe(1)
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    await createListing(web.id, { slug: 'food-hub' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await del('food-hub', web.id)
+
+    expect(response.status).toBe(403)
+    expect(await prisma.listing.count()).toBe(1)
+  })
+
+  it('lets an editor of the web delete it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    await createListing(web.id, { slug: 'food-hub' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await del('food-hub', web.id)
+
+    expect(response.status).toBe(200)
+    expect(await prisma.listing.count()).toBe(0)
+  })
+})

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { callerCanEditWeb, getCaller } from '@/lib/api-authorization'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -92,13 +93,18 @@ export async function GET(request: NextRequest) {
   }
 }
 
+/**
+ * Deliberately reachable without a session: this backs the propose-a-listing
+ * form anonymous visitors use. The admin form posts here too with
+ * `pending=false`, so every field that decides whether a listing goes live comes
+ * from the caller's rights over `webId`, never from the body.
+ */
 export async function POST(request) {
   try {
     const formData = await request.formData()
     const tags = formData.get('tags')
     const relations = formData.get('relations')
     const pending = formData.get('pending')
-    const proposerId = formData.get('proposerId')
     const webId = parseInt(formData.get('webId'))
     const category = parseInt(formData.get('category'))
     const title = formData.get('title')
@@ -115,21 +121,62 @@ export async function POST(request) {
     const socials = formData.get('socials')
     const actions = formData.get('actions')
 
-    // Prepare tags
-    const tagsArray = tags !== '' ? tags.split(',') : []
-    const tagsToConnect = tagsArray.map((tagId) => ({
-      id: Number(tagId),
-    }))
+    if (!Number.isInteger(webId)) {
+      return Response.json({ error: 'webId is required' }, { status: 400 })
+    }
 
-    // Prepare relations
-    const relationsArray = relations !== '' ? relations.split(',') : []
-    const relationsToConnect = relationsArray.map((relationId) => ({
-      id: Number(relationId),
-    }))
+    const web = await prisma.web.findFirst({
+      where: { id: webId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!web) {
+      return Response.json({ error: 'Web not found' }, { status: 404 })
+    }
 
-    const isProposedListing = stringToBoolean(pending)
+    const caller = await getCaller(request)
+    const callerIsEditor = await callerCanEditWeb(caller, webId)
+
+    // Everyone else gets a proposal, whatever the form said.
+    const isProposedListing = callerIsEditor ? stringToBoolean(pending) : true
+
+    // Whoever is signed in, never whoever the body names. Anonymous proposals
+    // are allowed and simply have none.
+    const proposerId = caller?.id
+
     const socialsData = socials ? JSON.parse(socials) : []
     const actionsData = actions ? JSON.parse(actions) : []
+
+    // Tags and categories are per-web, so only this web's may be attached.
+    const requestedTagIds = (
+      typeof tags === 'string' && tags !== '' ? tags.split(',') : []
+    )
+      .map(Number)
+      .filter(Number.isInteger)
+    const tagsToConnect =
+      requestedTagIds.length > 0
+        ? await prisma.tag.findMany({
+            where: { id: { in: requestedTagIds }, webId },
+            select: { id: true },
+          })
+        : []
+
+    const categoryInThisWeb = Number.isInteger(category)
+      ? await prisma.category.findFirst({
+          where: { id: category, webId },
+          select: { id: true },
+        })
+      : null
+
+    // Relating writes to the *other* listing too, so it stays an editor action.
+    const relationsToConnect = callerIsEditor
+      ? (typeof relations === 'string' && relations !== ''
+          ? relations.split(',')
+          : []
+        )
+          .map(Number)
+          .filter(Number.isInteger)
+          .map((id) => ({ id }))
+      : []
 
     const newData: Prisma.ListingCreateInput = {
       title: title,
@@ -180,7 +227,9 @@ export async function POST(request) {
         create: {
           web: { connect: { id: webId } },
           slug: slug as string,
-          ...(category ? { category: { connect: { id: category } } } : {}),
+          ...(categoryInThisWeb
+            ? { category: { connect: { id: categoryInThisWeb.id } } }
+            : {}),
           featured: isProposedListing ? null : featuredDate,
           ...(tagsToConnect.length > 0 && { tags: { connect: tagsToConnect } }),
         },
@@ -233,11 +282,13 @@ export async function POST(request) {
     }
 
     if (isProposedListing && selectedWeb) {
-      const proposer = await prisma.user.findUnique({
-        where: {
-          id: proposerId,
-        },
-      })
+      const proposer = proposerId
+        ? await prisma.user.findUnique({
+            where: {
+              id: proposerId,
+            },
+          })
+        : null
 
       const listingProposedEmailComponent = ListingProposedAdminEmail({
         proposedListingTitle: listing.title,

--- a/app/api/tags/[id]/listings/route.ts
+++ b/app/api/tags/[id]/listings/route.ts
@@ -1,22 +1,50 @@
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
+import { findTagWebId } from '../../authorization.ts'
 
 export async function PUT(
   request: NextRequest,
   props: { params: Promise<{ id: string }> },
 ) {
   const params = await props.params
-  const id = params.id
+  const tagId = Number(params.id)
+
+  const webId = await findTagWebId(tagId)
+  if (webId === null) {
+    return Response.json({ error: 'Tag not found' }, { status: 404 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
+
   const { addedListingIds, removedListingIds } = await request.json()
 
-  const listingIdsToConnect = addedListingIds.map((id) => ({ id }))
-  const listingIdsToDisconnect = removedListingIds.map((id) => ({ id }))
+  // A tag is per-web, so it may only ever reach placements in its own web.
+  const idsInThisWeb = async (ids: unknown) => {
+    const numeric = (Array.isArray(ids) ? ids : [])
+      .map(Number)
+      .filter(Number.isInteger)
+    if (numeric.length === 0) {
+      return []
+    }
+    const placements = await prisma.listingPlacement.findMany({
+      where: { id: { in: numeric }, webId },
+      select: { id: true },
+    })
+    return placements
+  }
 
   try {
+    const [listingIdsToConnect, listingIdsToDisconnect] = await Promise.all([
+      idsInThisWeb(addedListingIds),
+      idsInThisWeb(removedListingIds),
+    ])
+
     const tag = await prisma.tag.update({
       where: {
-        id: Number(id),
+        id: tagId,
       },
       data: {
         listings: {

--- a/app/api/tags/[id]/route.ts
+++ b/app/api/tags/[id]/route.ts
@@ -1,22 +1,36 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
+import { findTagWebId } from '../authorization.ts'
 
 export async function PATCH(
   request: NextRequest,
   props: { params: Promise<{ id: string }> },
 ) {
   const params = await props.params
-  const tagId = params.id
+  const tagId = Number(params.id)
   const body = await request.json()
 
+  const webId = await findTagWebId(tagId)
+  if (webId === null) {
+    return Response.json({ error: 'Tag not found' }, { status: 404 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
+
   try {
+    // Enumerated, not spread: `data: body` would let the caller move the tag
+    // to a web they have no rights over.
     const tag = await prisma.tag.update({
       where: {
-        id: Number(tagId),
+        id: tagId,
       },
-      data: body,
+      data: {
+        ...(body.label !== undefined ? { label: body.label } : {}),
+      },
       include: {
         web: {
           select: {
@@ -39,16 +53,24 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   props: { params: Promise<{ id: string }> },
 ) {
   const params = await props.params
-  const id = params.id
+  const tagId = Number(params.id)
+
+  const webId = await findTagWebId(tagId)
+  if (webId === null) {
+    return Response.json({ error: 'Tag not found' }, { status: 404 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
 
   try {
     const tag = await prisma.tag.delete({
       where: {
-        id: Number(id),
+        id: tagId,
       },
     })
 

--- a/app/api/tags/__tests__/route.integration.test.ts
+++ b/app/api/tags/__tests__/route.integration.test.ts
@@ -1,0 +1,231 @@
+import {
+  createListing,
+  createTag,
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { params, request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { PUT as putTagListings } from '../[id]/listings/route.ts'
+import { DELETE as deleteTag, PATCH as patchTag } from '../[id]/route.ts'
+import { POST as postTag } from '../route.ts'
+
+const asEditorOf = async (webId: number) => {
+  const { user } = await createUserWithWebAccess(webId, WebRole.EDITOR)
+  signInAs({ id: user.id, email: user.email })
+  return user
+}
+
+describe('POST /api/tags', () => {
+  it('rejects an anonymous caller', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await postTag(
+      request('/api/tags', {
+        method: 'POST',
+        body: { label: 'Volunteer-run', webId: web.id },
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.tag.count()).toBe(0)
+  })
+
+  it('rejects an editor of a different web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    await asEditorOf(otherWeb.id)
+
+    const response = await postTag(
+      request('/api/tags', {
+        method: 'POST',
+        body: { label: 'Volunteer-run', webId: web.id },
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.tag.count()).toBe(0)
+  })
+
+  it('lets an editor of the web create one', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    await asEditorOf(web.id)
+
+    const response = await postTag(
+      request('/api/tags', {
+        method: 'POST',
+        body: { label: 'Volunteer-run', webId: web.id },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(
+      (await prisma.tag.findFirst({ where: { webId: web.id } }))?.label,
+    ).toBe('Volunteer-run')
+  })
+})
+
+describe('PATCH /api/tags/[id]', () => {
+  it('rejects an editor of a different web and leaves the label alone', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id, { label: 'Volunteer-run' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    await asEditorOf(otherWeb.id)
+
+    const response = await patchTag(
+      request(`/api/tags/${tag.id}`, {
+        method: 'PATCH',
+        body: { label: 'Hijacked' },
+      }),
+      params({ id: String(tag.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(
+      (await prisma.tag.findUnique({ where: { id: tag.id } }))?.label,
+    ).toBe('Volunteer-run')
+  })
+
+  it('cannot be used to move a tag into another web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const tag = await createTag(web.id)
+    await asEditorOf(web.id)
+
+    await patchTag(
+      request(`/api/tags/${tag.id}`, {
+        method: 'PATCH',
+        body: { label: 'Renamed', webId: otherWeb.id },
+      }),
+      params({ id: String(tag.id) }),
+    )
+
+    expect(
+      (await prisma.tag.findUnique({ where: { id: tag.id } }))?.webId,
+    ).toBe(web.id)
+  })
+
+  it('lets a global admin rename any web tag', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id, { label: 'Volunteer-run' })
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await patchTag(
+      request(`/api/tags/${tag.id}`, {
+        method: 'PATCH',
+        body: { label: 'Volunteer led' },
+      }),
+      params({ id: String(tag.id) }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(
+      (await prisma.tag.findUnique({ where: { id: tag.id } }))?.label,
+    ).toBe('Volunteer led')
+  })
+})
+
+describe('DELETE /api/tags/[id]', () => {
+  it('rejects an anonymous caller and keeps the tag', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id)
+
+    const response = await deleteTag(
+      request(`/api/tags/${tag.id}`, { method: 'DELETE' }),
+      params({ id: String(tag.id) }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await prisma.tag.count()).toBe(1)
+  })
+
+  it('lets an editor of the web delete it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id)
+    await asEditorOf(web.id)
+
+    const response = await deleteTag(
+      request(`/api/tags/${tag.id}`, { method: 'DELETE' }),
+      params({ id: String(tag.id) }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await prisma.tag.count()).toBe(0)
+  })
+})
+
+describe('PUT /api/tags/[id]/listings', () => {
+  const putListings = (tagId: number, body: Record<string, unknown>) =>
+    putTagListings(
+      request(`/api/tags/${tagId}/listings`, { method: 'PUT', body }),
+      params({ id: String(tagId) }),
+    )
+
+  it('rejects an editor of a different web and leaves the listing untagged', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id)
+    const listing = await createListing(web.id)
+    const placementId = listing.placements[0]?.id
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    await asEditorOf(otherWeb.id)
+
+    const response = await putListings(tag.id, {
+      addedListingIds: [placementId],
+      removedListingIds: [],
+    })
+
+    expect(response.status).toBe(403)
+    expect(
+      await prisma.tag.findUnique({
+        where: { id: tag.id },
+        include: { listings: true },
+      }),
+    ).toMatchObject({ listings: [] })
+  })
+
+  it('tags the placements in its own web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id)
+    const listing = await createListing(web.id)
+    const placementId = listing.placements[0]?.id
+    await asEditorOf(web.id)
+
+    const response = await putListings(tag.id, {
+      addedListingIds: [placementId],
+      removedListingIds: [],
+    })
+
+    expect(response.status).toBe(200)
+    const tagged = await prisma.tag.findUnique({
+      where: { id: tag.id },
+      include: { listings: { select: { id: true } } },
+    })
+    expect(tagged?.listings.map((l) => l.id)).toEqual([placementId])
+  })
+
+  it('ignores placements that belong to another web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const tag = await createTag(web.id)
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const theirListing = await createListing(otherWeb.id)
+    const theirPlacementId = theirListing.placements[0]?.id
+    await asEditorOf(web.id)
+
+    const response = await putListings(tag.id, {
+      addedListingIds: [theirPlacementId],
+      removedListingIds: [],
+    })
+
+    expect(response.status).toBe(200)
+    const tagged = await prisma.tag.findUnique({
+      where: { id: tag.id },
+      include: { listings: true },
+    })
+    expect(tagged?.listings).toEqual([])
+  })
+})

--- a/app/api/tags/authorization.ts
+++ b/app/api/tags/authorization.ts
@@ -1,0 +1,13 @@
+import prisma from '@prisma-rw'
+
+/** The web a tag belongs to is what the caller needs rights over. */
+export async function findTagWebId(tagId: number) {
+  if (!Number.isInteger(tagId)) {
+    return null
+  }
+  const tag = await prisma.tag.findUnique({
+    where: { id: tagId },
+    select: { webId: true },
+  })
+  return tag?.webId ?? null
+}

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 
@@ -70,9 +71,23 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const body = await request.json()
+  const webId = Number(body?.webId)
+
+  if (!Number.isInteger(webId)) {
+    return Response.json({ error: 'webId is required' }, { status: 400 })
+  }
+
+  const denied = await requireWebEditor(request, webId)
+  if (denied) return denied
+
   try {
+    // Enumerated, not spread: `data: body` would let the caller set `webId`
+    // past the check above, or reach other webs through `listings`.
     const tag = await prisma.tag.create({
-      data: body,
+      data: {
+        webId,
+        label: body.label,
+      },
       include: {
         web: {
           select: {

--- a/app/api/users/__tests__/invite-route.integration.test.ts
+++ b/app/api/users/__tests__/invite-route.integration.test.ts
@@ -1,0 +1,107 @@
+import {
+  createUser,
+  createUserWithWebAccess,
+  createWeb,
+} from '@/test/factories'
+import { request } from '@/test/http'
+import { signInAs } from '@/test/session'
+import { WebRole } from '@prisma-client'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { POST } from '../invite/route.ts'
+
+const invite = (webId: number, email: string, asOwner = false) =>
+  POST(
+    request('/api/users/invite', {
+      method: 'POST',
+      body: { email, web: webId, asOwner },
+    }),
+  )
+
+describe('POST /api/users/invite', () => {
+  it('rejects an anonymous caller and grants nothing', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await invite(web.id, 'intruder@example.com')
+
+    expect(response.status).toBe(403)
+    expect(await prisma.webAccess.count()).toBe(0)
+  })
+
+  it('does not let a signed-in stranger make themselves an owner', async () => {
+    // The invite form is owner-only in the admin UI, so this was reachable
+    // only by posting directly - and it granted OWNER on any web.
+    const web = await createWeb({ slug: 'bristol' })
+    const stranger = await createUser()
+    signInAs({ id: stranger.id, email: stranger.email })
+
+    const response = await invite(web.id, stranger.email, true)
+
+    expect(response.status).toBe(403)
+    expect(await prisma.webAccess.count()).toBe(0)
+  })
+
+  it('does not let an editor of the web invite anyone', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.EDITOR)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await invite(web.id, 'new@example.com')
+
+    expect(response.status).toBe(403)
+    expect(await prisma.webAccess.count()).toBe(1)
+  })
+
+  it('does not let an owner of a different web invite', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const otherWeb = await createWeb({ slug: 'cambridge' })
+    const { user } = await createUserWithWebAccess(otherWeb.id, WebRole.OWNER)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await invite(web.id, 'new@example.com')
+
+    expect(response.status).toBe(403)
+    expect(await prisma.webAccess.count({ where: { webId: web.id } })).toBe(0)
+  })
+
+  it('lets an owner of the web invite an editor', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const { user } = await createUserWithWebAccess(web.id, WebRole.OWNER)
+    signInAs({ id: user.id, email: user.email })
+
+    const response = await invite(web.id, 'new@example.com')
+
+    expect(response.status).toBe(200)
+    expect(
+      await prisma.webAccess.findUnique({
+        where: { user_web_access: { email: 'new@example.com', webId: web.id } },
+      }),
+    ).toMatchObject({ role: WebRole.EDITOR })
+  })
+
+  it('lets a global admin invite an owner to any web', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await invite(web.id, 'new@example.com', true)
+
+    expect(response.status).toBe(200)
+    expect(
+      await prisma.webAccess.findUnique({
+        where: { user_web_access: { email: 'new@example.com', webId: web.id } },
+      }),
+    ).toMatchObject({ role: WebRole.OWNER })
+  })
+
+  it('404s for a soft-deleted web', async () => {
+    const web = await createWeb({ slug: 'bristol', deletedAt: new Date() })
+    const admin = await createUser({ role: 'admin' })
+    signInAs({ id: admin.id, email: admin.email, role: 'admin' })
+
+    const response = await invite(web.id, 'new@example.com')
+
+    expect(response.status).toBe(404)
+    expect(await prisma.webAccess.count()).toBe(0)
+  })
+})

--- a/app/api/users/invite/route.ts
+++ b/app/api/users/invite/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server'
+import { requireWebOwner } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 import { getSessionSafe } from '@auth'
@@ -41,6 +42,19 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Owner, not editor: this grants access, and the admin UI only offers the
+    // invite form to owners.
+    const denied = await requireWebOwner(request, Number(webId))
+    if (denied) return denied
+
+    const selectedWeb = await prisma.web.findFirst({
+      where: { id: Number(webId), deletedAt: null },
+    })
+
+    if (!selectedWeb) {
+      return Response.json({ error: 'Web not found' }, { status: 404 })
+    }
+
     if (asOwner) {
       await addUserToWeb(email, webId, 'OWNER')
     } else {
@@ -49,12 +63,6 @@ export async function POST(request: NextRequest) {
 
     const emailEncoded = encodeURIComponent(email)
     const callToActionButtonUrl = `${REMOTE_URL}/activate?email=${emailEncoded}`
-
-    const selectedWeb = await prisma.web.findUnique({
-      where: {
-        id: webId,
-      },
-    })
 
     const inviteEmailComponent = InviteEmail({
       webTitle: `${selectedWeb.title}`,

--- a/lib/api-authorization.ts
+++ b/lib/api-authorization.ts
@@ -1,0 +1,75 @@
+/**
+ * Web-scoped authorization for the route handlers under `app/api`. A session
+ * answers "who is this", not "may they write to *this* web".
+ *
+ * The guards return a `Response` when the caller is not allowed and `null` when
+ * they are, so a handler reads:
+ *
+ *   const denied = await requireWebEditor(request, webId)
+ *   if (denied) return denied
+ *
+ * A global admin (Better Auth's `role === 'admin'`) passes every check.
+ */
+import type { NextRequest } from 'next/server'
+import { getSessionSafe } from '@auth'
+import { canUserEditWeb, isUserOwnerOfWeb } from '@db/webAccessRepository'
+
+export interface Caller {
+  id: string
+  email: string
+  name?: string | null
+  role?: string
+}
+
+export async function getCaller(request: NextRequest): Promise<Caller | null> {
+  const session = await getSessionSafe(request.headers)
+  return session?.user ?? null
+}
+
+const forbidden = () =>
+  Response.json(
+    { error: "You don't have enough permissions to perform this action." },
+    { status: 403 },
+  )
+
+export async function callerCanEditWeb(
+  caller: Caller | null,
+  webId: number,
+): Promise<boolean> {
+  if (!caller?.email || !Number.isInteger(webId)) {
+    return false
+  }
+  if (caller.role === 'admin') {
+    return true
+  }
+  return canUserEditWeb(caller.email, webId)
+}
+
+export async function callerOwnsWeb(
+  caller: Caller | null,
+  webId: number,
+): Promise<boolean> {
+  if (!caller?.email || !Number.isInteger(webId)) {
+    return false
+  }
+  if (caller.role === 'admin') {
+    return true
+  }
+  return isUserOwnerOfWeb(caller.email, webId)
+}
+
+export async function requireWebEditor(
+  request: NextRequest,
+  webId: number,
+): Promise<Response | null> {
+  const caller = await getCaller(request)
+  return (await callerCanEditWeb(caller, webId)) ? null : forbidden()
+}
+
+export async function requireWebOwner(
+  request: NextRequest,
+  webId: number,
+): Promise<Response | null> {
+  const caller = await getCaller(request)
+  return (await callerOwnsWeb(caller, webId)) ? null : forbidden()
+}


### PR DESCRIPTION
Closes #512.

## Issue

Follow-up to #511, which fixed two endpoints that checked only *that* a caller was signed in, never *whether* they had rights to the web they were acting on. The same pattern ran through most of the mutating surface under `app/api/`, and several routes checked nothing at all.

## Background

All 30 non-`GET` handlers were audited. Findings:

| Endpoint | Was | Now |
|---|---|---|
| `POST /api/categories`, `PATCH`/`DELETE /api/categories/[id]` | no check at all | editor of the category's web |
| `POST /api/tags`, `PATCH`/`DELETE /api/tags/[id]` | no check at all | editor of the tag's web |
| `PUT /api/tags/[id]/listings` | no check at all | editor, plus placements scoped to the tag's web |
| `PUT`/`DELETE /api/listings/[slug]` | no check at all | editor of the web the placement is in |
| `PATCH /api/listing/[id]/feature`, `/unfeature` | no check at all | editor of the target web |
| `DELETE /api/listings/[slug]/edit` | session only | editor of the web, mirroring approve |
| `POST /api/users/invite` | session only | **owner** of the web |
| `POST /api/listings` | no check at all | stays public, hardened — see below |

`POST /api/users/invite` is the sharpest of these: the invite form is owner-only in the admin UI, so nothing looked wrong, but any registered user could grant themselves `OWNER` on any web by posting their own address.

Three routes were also escapable *after* a check would have passed, so those are closed too. `data: body` went straight into Prisma for categories and tags, letting a caller set `webId` to a web they cannot edit, or reach another web's placements through the `listings` relation. And `prisma.listing.update` is keyed on the listing alone, so passing a `webId` you *do* own reached a listing you do not.

## Solution

New `lib/api-authorization.ts` holds `requireWebEditor`, `requireWebOwner` and `callerCanEditWeb`, wrapping the existing `canUserEditWeb` / `isUserOwnerOfWeb` helpers with the admin bypass, so the next handler doesn't reinvent the check. Writes are pinned to the fields the forms own rather than spreading the request body, and a listing's placement is resolved before anything is written.

`POST /api/listings` stays reachable without a session — it backs the propose-a-listing form for anonymous visitors — but the admin form posts to the same endpoint with `pending=false`. Every field that decides whether a listing goes live now comes from the caller's rights rather than the body: `pending` is forced true for non-editors, the proposer is taken from the session, and the category and tags must belong to the target web. That incidentally fixes anonymous proposals, which 500 on `main`: the client appends the string `"undefined"` as `proposerId` and Prisma fails to connect it.

Per the issue, the two endpoints that are *deliberately* open — `POST /api/listings` and the propose-an-edit `POST /api/listings/[slug]/edit` — record that intent in a comment, so a later audit doesn't "fix" them. The rest of the public surface (`/api/contact`, `/api/analytics/track`, `/api/newsletter-subscribe`, `/api/users/check-email`) and the self-scoped routes (`/api/users`, `/api/notifications/*`, `POST /api/webs`) were audited and left alone — the code states its own case there.

## Steps to test

`npm run test:integration` — 129 pass.

37 of those are new, covering the negative case per endpoint: wrong web gives a non-2xx **and** the database is unchanged, following the pattern in `app/api/webs/__tests__/slug-route.integration.test.ts`. To confirm they fail for the right reason, stash the route changes and keep the tests: all 37 go red, and pass again with the fixes in place.

`npm run quality:dry` is clean (one pre-existing unrelated warning in `ListingsMap.tsx`).

## Left out

Two `GET` leaks of the same shape, outside what #512 asked for:

- `GET /api/web-access?web=<slug>` returns a web's whole team list, emails included, to any signed-in user. Same class as the `listing-edits` leak #511 fixed; roughly a one-line fix.
- `GET /api/listings/[slug]/edit` returns pending edits with `include: { user: true }`, so the proposer's full row. The public propose page calls it only to ask "is an edit already pending?", so this wants a narrowed payload rather than a gate — worth a product call.

Also a latent bug, unrelated to authorization: `AddTagToListingsDialog.tsx` sends `Listing` ids where `Tag.listings` is a `ListingPlacement[]` relation. The new web-scoping filter ignores non-matching ids rather than erroring, so it fails quietly exactly as it did before. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
