### PR TITLE
test: extend the component-test layer to the remaining key user flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,13 +249,20 @@ Render the real component and drive it as a visitor would — type, click, selec
 in the test, and don't assert on props or internal state.
 
 Setup lives in [test/setup/components.tsx](test/setup/components.tsx). It stubs
-the browser APIs Radix needs (`ResizeObserver`, pointer capture), and the three
-Next modules that have no implementation under jsdom:
+the browser APIs Radix needs (`ResizeObserver`, pointer capture), and the
+modules that have no implementation under jsdom:
 
 - `next/navigation` — backed by [test/next-navigation.ts](test/next-navigation.ts),
   so a test can `setRoute()` or assert on `router.push`
 - `next/image` and `next/link` — rendered as the plain `<img>` / `<a>` they
   become in the browser
+- `@auth-client` — Better Auth keeps the session in the browser, so `useSession`
+  reads from [test/session.ts](test/session.ts) instead; a test signs in with
+  `signInAs()`, the same helper the integration tests use
+- `@tinymce/tinymce-react` — the rich text editor downloads itself from a CDN,
+  so it renders as the text box it stands in for and a test types into it
+- `posthog-js` — analytics is an outbound edge; tests drive real journeys and
+  must not report them anywhere
 
 Keeping all of that in the setup file is deliberate: **the tests themselves
 contain no Next-specific code**, so they survive a change of framework.
@@ -264,15 +271,21 @@ Writing one:
 
 - Render with `renderPage()` from [test/render.tsx](test/render.tsx), which
   provides React Query and nuqs and hands back a `user`. Pass `searchParams` to
-  start the test on a particular URL state.
+  start the test on a particular URL state, and `selectedWeb` to put an admin
+  screen inside a particular web — that is what every one of them reads through
+  `useAppContext`.
 - Stub the API with **MSW**, not by mocking hooks — see
-  [test/msw/handlers.ts](test/msw/handlers.ts) and the `stubCategories()` /
-  `stubTags()` helpers. Intercepting HTTP keeps the React Query hooks, their
+  [test/msw/handlers.ts](test/msw/handlers.ts) and the `stub*` helpers
+  (`stubCategories`, `stubTags`, `stubListings`, `stubWeb`, `stubListingEdits`,
+  `stubCanEditWeb`). Intercepting HTTP keeps the React Query hooks, their
   caching and their error handling real. An unstubbed request fails the test
   rather than resolving to something unexpected.
-- Build page props with the fixtures in [test/fixtures/](test/fixtures/) —
+- Assert on the change a component asked for with `recordRequests()`, which
+  stubs a request and remembers what was sent — the URL and the body, whether
+  it went as JSON or as a form.
+- Build props with the fixtures in [test/fixtures/](test/fixtures/) —
   `webData([{ title, category }])` returns the compressed payload the web page
-  expects.
+  expects, and `listing({ title })` a listing in the shape the client sees it.
 
 ```tsx
 const { user } = renderPage(<Web data={webData(LISTINGS)} webSlug="bristol" />, {

--- a/app/admin/categories/__tests__/page.test.tsx
+++ b/app/admin/categories/__tests__/page.test.tsx
@@ -1,0 +1,275 @@
+import {
+  recordRequests,
+  stubCategories,
+  stubListings,
+  stubTags,
+} from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { renderPage } from '@/test/render'
+import { screen, waitFor, within } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+import CategoriesPage from '../page.tsx'
+
+/**
+ * The screen where an editor shapes the vocabulary of their web: the
+ * categories every listing must belong to, and the tags that cut across them.
+ *
+ * Both halves are the same three actions — create, rename, delete — with one
+ * rule that matters: neither can be deleted while listings still use it.
+ */
+
+const CATEGORIES = [
+  { id: 1, label: 'Community', color: 'b0e3c1', _count: { listings: 2 } },
+  { id: 2, label: 'Transport', color: 'ffd6a5', _count: { listings: 0 } },
+]
+
+const TAGS = [
+  { id: 5, label: 'Volunteer-run', listings: [], _count: { listings: 0 } },
+  {
+    id: 6,
+    label: 'Free',
+    listings: [{ id: 1 }],
+    _count: { listings: 1 },
+  },
+]
+
+const renderCategoriesPage = () =>
+  renderPage(<CategoriesPage />, { selectedWeb: { slug: 'bristol', id: 3 } })
+
+/** The table row for one category or tag, named after its label. */
+const rowFor = (label: string) =>
+  screen.getByRole('row', { name: new RegExp(`^${label}\\b`) })
+
+const openTagsTab = (user: ReturnType<typeof renderPage>['user']) =>
+  user.click(screen.getByRole('tab', { name: 'Tags' }))
+
+beforeEach(() => {
+  server.use(
+    stubCategories(CATEGORIES),
+    stubTags(TAGS),
+    stubListings([{ id: 1, title: 'Bike Kitchen', tags: [] }]),
+  )
+})
+
+describe('the categories an editor has set up', () => {
+  it('are listed with how many listings use each one', async () => {
+    renderCategoriesPage()
+
+    expect(
+      await screen.findByRole('cell', { name: 'Community' }),
+    ).toBeInTheDocument()
+    expect(rowFor('Community')).toHaveTextContent('2')
+    expect(rowFor('Transport')).toHaveTextContent('0')
+  })
+})
+
+describe('creating a category', () => {
+  it('sends the new label, capitalised, for the web being edited', async () => {
+    const created = recordRequests({ category: { id: 9 } })
+    server.use(http.post('/api/categories', created.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await user.click(
+      await screen.findByRole('button', { name: /new category/i }),
+    )
+    await user.type(
+      await screen.findByLabelText('Category label'),
+      'food growing',
+    )
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(created.calls).toHaveLength(1))
+    expect(created.calls[0].body).toMatchObject({
+      label: 'Food growing',
+      webId: 3,
+    })
+  })
+
+  it('closes the dialog once the category is on its way', async () => {
+    server.use(http.post('/api/categories', () => HttpResponse.json({})))
+    const { user } = renderCategoriesPage()
+
+    await user.click(
+      await screen.findByRole('button', { name: /new category/i }),
+    )
+    await user.type(await screen.findByLabelText('Category label'), 'Food')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Category label')).toBeNull(),
+    )
+  })
+})
+
+describe('renaming a category', () => {
+  it('arrives with the current label and sends the new one', async () => {
+    const updated = recordRequests({ data: {} })
+    server.use(http.patch('/api/categories/:id', updated.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await user.click(
+      within(
+        await screen.findByRole('row', { name: /^Transport\b/ }),
+      ).getByRole('button', { name: 'Edit' }),
+    )
+
+    const label = await screen.findByLabelText('Category label')
+    expect(label).toHaveValue('Transport')
+
+    await user.clear(label)
+    await user.type(label, 'Getting around')
+    await user.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(updated.calls).toHaveLength(1))
+    expect(updated.calls[0].url.pathname).toBe('/api/categories/2')
+    expect(updated.calls[0].body).toMatchObject({ label: 'Getting around' })
+  })
+})
+
+describe('deleting a category', () => {
+  it('is allowed once nothing is using it', async () => {
+    const deleted = recordRequests({ category: {} })
+    server.use(http.delete('/api/categories/:id', deleted.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await user.click(
+      within(
+        await screen.findByRole('row', { name: /^Transport\b/ }),
+      ).getByRole('button', { name: 'Edit' }),
+    )
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => expect(deleted.calls).toHaveLength(1))
+    expect(deleted.calls[0].url.pathname).toBe('/api/categories/2')
+  })
+
+  it('is refused while listings still belong to it', async () => {
+    const { user } = renderCategoriesPage()
+
+    await user.click(
+      within(
+        await screen.findByRole('row', { name: /^Community\b/ }),
+      ).getByRole('button', { name: 'Edit' }),
+    )
+
+    expect(await screen.findByRole('button', { name: 'Remove' })).toBeDisabled()
+  })
+})
+
+describe('the tags an editor has set up', () => {
+  it('are listed with how many listings carry each one', async () => {
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+
+    expect(
+      await screen.findByRole('cell', { name: 'Volunteer-run' }),
+    ).toBeInTheDocument()
+    expect(rowFor('Free')).toHaveTextContent('1')
+  })
+})
+
+describe('creating a tag', () => {
+  it('sends the new label for the web being edited', async () => {
+    const created = recordRequests({ data: { id: 9 } })
+    server.use(http.post('/api/tags', created.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+
+    await user.click(await screen.findByRole('button', { name: /new tag/i }))
+    await user.type(await screen.findByLabelText('Tag label'), 'Repair')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(created.calls).toHaveLength(1))
+    expect(created.calls[0].body).toMatchObject({ label: 'Repair', webId: 3 })
+  })
+
+  it('will not create a tag with no label', async () => {
+    const created = recordRequests({ data: {} })
+    server.use(http.post('/api/tags', created.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+    await user.click(await screen.findByRole('button', { name: /new tag/i }))
+
+    expect(await screen.findByRole('button', { name: 'Create' })).toBeDisabled()
+    expect(created.calls).toHaveLength(0)
+  })
+})
+
+describe('renaming a tag', () => {
+  it('arrives with the current label and sends the new one', async () => {
+    const updated = recordRequests({ tag: {} })
+    server.use(http.patch('/api/tags/:id', updated.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+
+    await user.click(
+      within(
+        await screen.findByRole('row', { name: /^Volunteer-run\b/ }),
+      ).getByRole('button', { name: 'Edit' }),
+    )
+
+    const label = await screen.findByLabelText('Tag label')
+    expect(label).toHaveValue('Volunteer-run')
+
+    await user.clear(label)
+    await user.type(label, 'Run by volunteers')
+    await user.click(screen.getByRole('button', { name: 'Update' }))
+
+    await waitFor(() => expect(updated.calls).toHaveLength(1))
+    expect(updated.calls[0].url.pathname).toBe('/api/tags/5')
+    expect(updated.calls[0].body).toMatchObject({ label: 'Run by volunteers' })
+  })
+})
+
+describe('deleting a tag', () => {
+  it('is allowed once nothing is using it', async () => {
+    const deleted = recordRequests({ tag: {} })
+    server.use(http.delete('/api/tags/:id', deleted.resolver))
+
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+
+    await user.click(
+      within(
+        await screen.findByRole('row', { name: /^Volunteer-run\b/ }),
+      ).getByRole('button', { name: 'Edit' }),
+    )
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => expect(deleted.calls).toHaveLength(1))
+    expect(deleted.calls[0].url.pathname).toBe('/api/tags/5')
+  })
+
+  it('is refused while listings still carry it', async () => {
+    const { user } = renderCategoriesPage()
+
+    await screen.findByRole('cell', { name: 'Community' })
+    await openTagsTab(user)
+
+    await user.click(
+      within(await screen.findByRole('row', { name: /^Free\b/ })).getByRole(
+        'button',
+        { name: 'Edit' },
+      ),
+    )
+
+    expect(await screen.findByRole('button', { name: 'Remove' })).toBeDisabled()
+  })
+})

--- a/app/edit/[webSlug]/[listingSlug]/__tests__/EditListing.test.tsx
+++ b/app/edit/[webSlug]/[listingSlug]/__tests__/EditListing.test.tsx
@@ -1,0 +1,159 @@
+import { listing } from '@/test/fixtures/listing'
+import {
+  recordRequests,
+  stubCategories,
+  stubListingEdits,
+  stubWeb,
+} from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { router } from '@/test/next-navigation'
+import { renderPage } from '@/test/render'
+import { screen, waitFor, within } from '@testing-library/react'
+import { http } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+import EditListing from '../EditListing.tsx'
+
+/**
+ * The form anyone can use to suggest a change to an existing listing. Nothing
+ * they type reaches the listing directly — it becomes a `ListingEdit` for the
+ * web's editors to accept or reject — so what matters here is that the form
+ * arrives filled in with the listing as it stands, and that a suggestion is
+ * sent for the right listing.
+ */
+
+const LISTING = listing({
+  id: 12,
+  title: 'Bike Kitchen',
+  description: 'A workshop where volunteers help you fix your own bicycle.',
+  website: 'https://bikekitchen.org',
+})
+
+function suggestion() {
+  const suggested = recordRequests({ listing: LISTING })
+  server.use(http.post('/api/listings/:slug/edit', suggested.resolver))
+  return suggested
+}
+
+const editForm = () =>
+  screen.getByLabelText(/^Title/).closest('form') as HTMLElement
+
+/** The page footer has a newsletter Submit of its own, so scope to the form. */
+const submit = (user: ReturnType<typeof renderPage>['user']) =>
+  user.click(within(editForm()).getByRole('button', { name: 'Submit' }))
+
+const renderEditPage = () =>
+  renderPage(<EditListing listing={LISTING} webSlug="bristol" />)
+
+beforeEach(() => {
+  server.use(
+    stubWeb({ id: 3, title: 'Bristol', slug: 'bristol' }),
+    stubCategories([
+      { id: 4, label: 'Community' },
+      { id: 7, label: 'Environment' },
+    ]),
+    stubListingEdits([]),
+  )
+})
+
+describe('suggesting an edit to a listing', () => {
+  it('arrives filled in with the listing as it stands', async () => {
+    renderEditPage()
+
+    expect(await screen.findByLabelText(/^Title/)).toHaveValue('Bike Kitchen')
+    expect(screen.getByLabelText('Website')).toHaveValue(
+      'https://bikekitchen.org',
+    )
+    expect(screen.getByLabelText(/^Description/)).toHaveValue(
+      'A workshop where volunteers help you fix your own bicycle.',
+    )
+  })
+
+  it('says the changes go to the web maintainers for review', async () => {
+    renderEditPage()
+
+    expect(
+      await screen.findByText(/will be submitted to the maintainers/i),
+    ).toBeInTheDocument()
+  })
+
+  it('does not let the listing move to a different page address', async () => {
+    renderEditPage()
+
+    await screen.findByLabelText(/^Title/)
+    expect(screen.queryByLabelText(/Link to listing page/)).toBeNull()
+  })
+
+  it('refuses to suggest a listing with no title', async () => {
+    const suggested = suggestion()
+    const { user } = renderEditPage()
+
+    await user.clear(await screen.findByLabelText(/^Title/))
+    await submit(user)
+
+    expect(await screen.findByText('Title is required')).toBeInTheDocument()
+    expect(suggested.calls).toHaveLength(0)
+  })
+
+  it('sends the change against the listing it was opened for', async () => {
+    const suggested = suggestion()
+    const { user } = renderEditPage()
+
+    const title = await screen.findByLabelText(/^Title/)
+    await user.clear(title)
+    await user.type(title, 'Bristol Bike Kitchen')
+    await submit(user)
+
+    await waitFor(() => expect(suggested.calls).toHaveLength(1))
+    expect(suggested.calls[0].url.pathname).toBe(
+      '/api/listings/bike-kitchen/edit',
+    )
+    expect(suggested.calls[0].url.searchParams.get('web')).toBe('bristol')
+    expect(suggested.calls[0].body).toMatchObject({
+      title: 'Bristol Bike Kitchen',
+      listingId: '12',
+      webId: '3',
+    })
+  })
+
+  it('thanks the contributor once the suggestion is in', async () => {
+    suggestion()
+    const { user } = renderEditPage()
+
+    const title = await screen.findByLabelText(/^Title/)
+    await user.clear(title)
+    await user.type(title, 'Bristol Bike Kitchen')
+    await submit(user)
+
+    expect(
+      await screen.findByRole(
+        'heading',
+        { name: /thank you/i },
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Title/)).toBeNull()
+  })
+})
+
+describe('a listing that is already under review', () => {
+  it('cannot be edited again until the first suggestion is dealt with', async () => {
+    server.use(stubListingEdits([{ id: 90, title: 'Bristol Bike Kitchen' }]))
+    renderEditPage()
+
+    expect(
+      await screen.findByText(/already a suggested edit under review/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Title/)).toBeNull()
+  })
+
+  it('sends the visitor back to the listing they came from', async () => {
+    server.use(stubListingEdits([{ id: 90 }]))
+    const { user } = renderEditPage()
+
+    await user.click(
+      await screen.findByRole('button', { name: /go back to listing/i }),
+    )
+
+    expect(router.back).toHaveBeenCalled()
+  })
+})

--- a/app/new-listing/[webSlug]/__tests__/NewListing.test.tsx
+++ b/app/new-listing/[webSlug]/__tests__/NewListing.test.tsx
@@ -1,0 +1,156 @@
+import { stubCategories, recordRequests, stubWeb } from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { renderPage } from '@/test/render'
+import { signInAs } from '@/test/session'
+import { screen, waitFor, within } from '@testing-library/react'
+import { http } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+import NewListing from '../NewListing.tsx'
+
+/**
+ * The form a visitor fills in to propose a listing for a web they don't run.
+ * What they submit becomes a pending listing for that web's editors to review,
+ * so the test cares about two things: that the form refuses to send an
+ * incomplete proposal, and that what it does send is what was typed.
+ */
+
+const CATEGORIES = [
+  { id: 4, label: 'Community' },
+  { id: 7, label: 'Environment' },
+]
+
+function proposal() {
+  const created = recordRequests({ listing: { slug: 'bike-kitchen' } })
+  server.use(http.post('/api/listings', created.resolver))
+  return created
+}
+
+beforeEach(() => {
+  signInAs({ id: 'user-1', email: 'visitor@example.com' })
+  server.use(
+    stubWeb({ id: 3, title: 'Bristol', slug: 'bristol' }),
+    stubCategories(CATEGORIES),
+  )
+})
+
+/** Fills in everything the form requires, leaving the optional fields alone. */
+async function fillInTheRequiredFields(
+  user: ReturnType<typeof renderPage>['user'],
+  { title = 'Bike Kitchen', description = 'We fix bicycles together.' } = {},
+) {
+  await user.type(await screen.findByLabelText(/^Title/), title)
+
+  await user.click(screen.getByRole('combobox'))
+  await user.click(await screen.findByRole('option', { name: 'Community' }))
+
+  await user.type(screen.getByLabelText(/^Description/), description)
+}
+
+/**
+ * The page footer carries a newsletter sign-up with a Submit button of its
+ * own, so everything the form does is scoped to the form.
+ */
+const listingForm = () =>
+  screen.getByLabelText(/^Title/).closest('form') as HTMLElement
+
+const submit = (user: ReturnType<typeof renderPage>['user']) =>
+  user.click(within(listingForm()).getByRole('button', { name: 'Submit' }))
+
+describe('proposing a listing', () => {
+  it('tells the visitor which web they are proposing to', async () => {
+    renderPage(<NewListing webSlug="bristol" />)
+
+    expect(
+      await screen.findByRole('heading', { name: /propose new listing/i }),
+    ).toBeInTheDocument()
+    expect(await screen.findByText(/Bristol/)).toBeInTheDocument()
+  })
+
+  it('offers the categories of the web being proposed to', async () => {
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await user.click(await screen.findByRole('combobox'))
+
+    expect(
+      await screen.findByRole('option', { name: 'Community' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: 'Environment' }),
+    ).toBeInTheDocument()
+  })
+
+  it('refuses an incomplete proposal and says what is missing', async () => {
+    const proposed = proposal()
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await user.type(await screen.findByLabelText(/^Title/), 'Bike Kitchen')
+    await submit(user)
+
+    expect(
+      await screen.findByText('Description is required'),
+    ).toBeInTheDocument()
+    expect(proposed.calls).toHaveLength(0)
+  })
+
+  it('refuses a website that is not a link', async () => {
+    const proposed = proposal()
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await fillInTheRequiredFields(user)
+    await user.type(screen.getByLabelText('Website'), 'not-a-website')
+    await submit(user)
+
+    expect(
+      await screen.findByText(/Please enter a valid URL/),
+    ).toBeInTheDocument()
+    expect(proposed.calls).toHaveLength(0)
+  })
+
+  it('sends what the visitor typed, as a proposal for that web', async () => {
+    const proposed = proposal()
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await fillInTheRequiredFields(user)
+    await submit(user)
+
+    await waitFor(() => expect(proposed.calls).toHaveLength(1))
+    expect(proposed.calls[0].body).toMatchObject({
+      title: 'Bike Kitchen',
+      description: 'We fix bicycles together.',
+      category: '4',
+      webId: '3',
+      pending: 'true',
+      proposerId: 'user-1',
+    })
+  })
+
+  it('gives the listing a page address based on its title', async () => {
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await user.type(
+      await screen.findByLabelText(/^Title/),
+      'Bristol Bike Kitchen',
+    )
+
+    expect(screen.getByLabelText(/Link to listing page/)).toHaveValue(
+      'bristol-bike-kitchen',
+    )
+  })
+
+  it('thanks the visitor once the proposal is in', async () => {
+    proposal()
+    const { user } = renderPage(<NewListing webSlug="bristol" />)
+
+    await fillInTheRequiredFields(user)
+    await submit(user)
+
+    expect(
+      await screen.findByRole(
+        'heading',
+        { name: /thank you/i },
+        { timeout: 3000 },
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Title/)).toBeNull()
+  })
+})

--- a/components/admin/editable-list/__tests__/EditableList.test.tsx
+++ b/components/admin/editable-list/__tests__/EditableList.test.tsx
@@ -1,0 +1,309 @@
+import { listing } from '@/test/fixtures/listing'
+import {
+  recordRequests,
+  stubCanEditWeb,
+  stubCategories,
+  stubWeb,
+} from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { renderPage } from '@/test/render'
+import { signInAs } from '@/test/session'
+import { screen, waitFor, within } from '@testing-library/react'
+import { http } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EditableList from '../EditableList.tsx'
+
+/**
+ * The table an editor lands on in the admin: every listing in their web, with
+ * the ones that need attention first and the handful of things they can do to
+ * one without opening it.
+ */
+
+const LISTINGS = [
+  listing({ id: 1, title: 'Bike Kitchen', category: { label: 'Transport' } }),
+  listing({ id: 2, title: 'Repair Cafe', category: { label: 'Community' } }),
+  listing({
+    id: 3,
+    title: 'Wild Swimming',
+    category: { label: 'Community' },
+  }),
+]
+
+const ALL_TITLES = LISTINGS.map((l) => l.title)
+
+function renderList(
+  { items = LISTINGS, searchParams = {} } = {},
+  deleteListing = vi.fn(),
+) {
+  return {
+    deleteListing,
+    ...renderPage(
+      <EditableList items={items} deleteListing={deleteListing} />,
+      {
+        selectedWeb: { slug: 'bristol', id: 3 },
+        searchParams,
+      },
+    ),
+  }
+}
+
+/** A listing has a row of its own, named after its title. */
+const row = (title: string) =>
+  screen.queryByRole('row', { name: new RegExp(title) })
+
+const expectListed = (titles: string[]) =>
+  titles.forEach((title) => expect(row(title)).toBeInTheDocument())
+
+const expectNotListed = (titles: string[]) =>
+  titles.forEach((title) => expect(row(title)).toBeNull())
+
+beforeEach(() => {
+  signInAs({ id: 'editor-1', email: 'editor@example.com' })
+  server.use(
+    stubCanEditWeb(true),
+    stubWeb({ id: 3, slug: 'bristol' }),
+    stubCategories([
+      { id: 1, label: 'Transport' },
+      { id: 2, label: 'Community' },
+    ]),
+  )
+})
+
+describe('the admin listings table', () => {
+  it('lists every listing in the web', async () => {
+    renderList()
+
+    await waitFor(() => expectListed(ALL_TITLES))
+  })
+
+  it('narrows the table as the editor types', async () => {
+    const { user } = renderList()
+    await waitFor(() => expectListed(ALL_TITLES))
+
+    await user.type(await screen.findByPlaceholderText('Search'), 'repair')
+
+    expectListed(['Repair Cafe'])
+    expectNotListed(['Bike Kitchen', 'Wild Swimming'])
+  })
+
+  it('shows only the chosen category, and restores the rest afterwards', async () => {
+    const { user } = renderList()
+    await waitFor(() => expectListed(ALL_TITLES))
+
+    await user.click(await screen.findByText('Filter by category'))
+    await user.click(await screen.findByRole('option', { name: 'Community' }))
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => expectNotListed(['Bike Kitchen']))
+    expectListed(['Repair Cafe', 'Wild Swimming'])
+
+    await user.click(screen.getByRole('button', { name: 'Remove Community' }))
+
+    await waitFor(() => expectListed(ALL_TITLES))
+  })
+
+  it('starts filtered when the URL already names a category', async () => {
+    renderList({ searchParams: { categories: 'Transport' } })
+
+    await waitFor(() => expectListed(['Bike Kitchen']))
+    expectNotListed(['Repair Cafe', 'Wild Swimming'])
+  })
+
+  it('says so when nothing matches, and offers a way to add one', async () => {
+    const { user } = renderList()
+    await waitFor(() => expectListed(ALL_TITLES))
+
+    await user.type(
+      await screen.findByPlaceholderText('Search'),
+      'nothing matches this',
+    )
+
+    expect(screen.getByText(/No listings yet/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /start adding/i })).toHaveAttribute(
+      'href',
+      '/admin/new-listing',
+    )
+  })
+
+  it('puts what needs attention first', async () => {
+    renderList({
+      items: [
+        listing({ id: 1, title: 'Bike Kitchen' }),
+        listing({ id: 2, title: 'Repair Cafe', pending: true }),
+        listing({ id: 3, title: 'Wild Swimming', edits: [{ id: 90 }] }),
+      ],
+    })
+
+    await waitFor(() => expectListed(ALL_TITLES))
+    const titles = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((r) => r.textContent)
+
+    expect(titles[0]).toContain('Wild Swimming')
+    expect(titles[1]).toContain('Repair Cafe')
+    expect(titles[2]).toContain('Bike Kitchen')
+  })
+
+  it('marks a proposed listing as pending and sends the editor to review it', async () => {
+    renderList({
+      items: [listing({ id: 1, title: 'Bike Kitchen', pending: true })],
+    })
+
+    const bikeKitchen = within(
+      await screen.findByRole('row', { name: /Bike Kitchen/ }),
+    )
+    expect(bikeKitchen.getByText('Pending')).toBeInTheDocument()
+    expect(bikeKitchen.getByRole('link', { name: 'Review' })).toHaveAttribute(
+      'href',
+      '/admin/listings/bike-kitchen',
+    )
+  })
+
+  it('offers a way through to a suggested edit', async () => {
+    renderList({
+      items: [listing({ id: 1, title: 'Bike Kitchen', edits: [{ id: 90 }] })],
+    })
+
+    const bikeKitchen = within(
+      await screen.findByRole('row', { name: /Bike Kitchen/ }),
+    )
+    expect(
+      bikeKitchen.getByRole('link', { name: /view suggested edit/i }),
+    ).toHaveAttribute('href', '/admin/listings/bike-kitchen/edits')
+  })
+
+  it('flags a listing that is missing an image, a location or a real description', async () => {
+    renderList({
+      items: [
+        listing({ id: 1, title: 'Bike Kitchen', description: 'Too short.' }),
+      ],
+    })
+
+    const bikeKitchen = within(
+      await screen.findByRole('row', { name: /Bike Kitchen/ }),
+    )
+    expect(bikeKitchen.getByText('No image')).toBeInTheDocument()
+    expect(bikeKitchen.getByText('No location')).toBeInTheDocument()
+    expect(bikeKitchen.getByText('Short description')).toBeInTheDocument()
+  })
+})
+
+describe('featuring a listing', () => {
+  const inTheFuture = '2099-01-01T00:00:00.000Z'
+
+  it('lifts a listing to the top of the web page for a while', async () => {
+    const featured = recordRequests({ listing: {} })
+    server.use(http.patch('*/api/listing/:id/feature', featured.resolver))
+
+    const { user } = renderList({
+      items: [listing({ id: 7, title: 'Bike Kitchen' })],
+    })
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Feature Bike Kitchen' }),
+    )
+
+    await waitFor(() => expect(featured.calls).toHaveLength(1))
+    expect(featured.calls[0].url.pathname).toBe('/api/listing/7/feature')
+    expect(featured.calls[0].body).toMatchObject({ webId: 3 })
+  })
+
+  it('takes an already-featured listing back down', async () => {
+    const unfeatured = recordRequests({ listing: {} })
+    server.use(http.patch('*/api/listing/:id/unfeature', unfeatured.resolver))
+
+    const { user } = renderList({
+      items: [listing({ id: 7, title: 'Bike Kitchen', featured: inTheFuture })],
+    })
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Unfeature Bike Kitchen' }),
+    )
+
+    await waitFor(() => expect(unfeatured.calls).toHaveLength(1))
+    expect(unfeatured.calls[0].url.pathname).toBe('/api/listing/7/unfeature')
+  })
+
+  it('treats a listing whose spell in the spotlight has passed as not featured', async () => {
+    renderList({
+      items: [
+        listing({
+          id: 7,
+          title: 'Bike Kitchen',
+          featured: '2020-01-01T00:00:00.000Z',
+        }),
+      ],
+    })
+
+    expect(
+      await screen.findByRole('button', { name: 'Feature Bike Kitchen' }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('removing a listing', () => {
+  it('asks before deleting, and deletes what was asked for', async () => {
+    const { user, deleteListing } = renderList({
+      items: [listing({ id: 7, title: 'Bike Kitchen' })],
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    expect(
+      await screen.findByText(/can't be recovered once deleted/i),
+    ).toBeInTheDocument()
+    expect(deleteListing).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Yes, delete' }))
+
+    expect(deleteListing).toHaveBeenCalledWith({
+      slug: 'bike-kitchen',
+      webId: 3,
+    })
+  })
+
+  it('lets the editor change their mind', async () => {
+    const { user, deleteListing } = renderList({
+      items: [listing({ id: 7, title: 'Bike Kitchen' })],
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    expect(deleteListing).not.toHaveBeenCalled()
+  })
+
+  it('explains that a shared listing only leaves this web', async () => {
+    const { user } = renderList({
+      items: [
+        listing({
+          id: 7,
+          title: 'Bike Kitchen',
+          sharedWith: [{ web: { title: 'Bath' } }],
+        }),
+      ],
+    })
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    expect(
+      await screen.findByText(/It will stay listed in Bath/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Yes, remove' }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('someone who may not edit this web', () => {
+  it('is not offered the search, the filter or a way to add a listing', async () => {
+    server.use(stubCanEditWeb(false))
+    renderList()
+
+    await waitFor(() => expectListed(ALL_TITLES))
+    expect(screen.queryByPlaceholderText('Search')).toBeNull()
+    expect(screen.queryByText('Filter by category')).toBeNull()
+    expect(screen.queryByRole('button', { name: /new listing/i })).toBeNull()
+  })
+})

--- a/components/admin/editable-list/table/Table.tsx
+++ b/components/admin/editable-list/table/Table.tsx
@@ -125,6 +125,11 @@ const TableContent = ({ items, removeItem }) => {
                       title="Display this listing at the top of the web page for 7 days."
                     >
                       <button
+                        aria-label={
+                          isFeatured
+                            ? `Unfeature ${item.title}`
+                            : `Feature ${item.title}`
+                        }
                         className="rounded-full bg-gray-100 p-2 text-xl hover:bg-gray-200"
                         onClick={() => {
                           if (isFeatured) {

--- a/components/admin/listing-form/ListingFormSimplified.tsx
+++ b/components/admin/listing-form/ListingFormSimplified.tsx
@@ -74,7 +74,9 @@ const SlugField = ({ webSlug }) => {
             <span className="inline-flex shrink-0 items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
               {`${webSlug}.resilienceweb.org.uk/`}
             </span>
-            <Input {...field} className="rounded-l-none" />
+            <FormControl>
+              <Input {...field} className="rounded-l-none" />
+            </FormControl>
           </div>
           <FormMessage />
         </FormItem>

--- a/components/admin/listing-form/listing-edit-review/__tests__/ListingEditReview.test.tsx
+++ b/components/admin/listing-form/listing-edit-review/__tests__/ListingEditReview.test.tsx
@@ -1,0 +1,187 @@
+import { listing, type ListingFixtureOverrides } from '@/test/fixtures/listing'
+import { recordRequests } from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { router } from '@/test/next-navigation'
+import { renderPage } from '@/test/render'
+import { screen, waitFor } from '@testing-library/react'
+import { http } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+import ListingEditReview from '../ListingEditReview.tsx'
+
+/**
+ * What a web editor sees when someone has suggested a change to one of their
+ * listings: the listing as it stands with the suggestion marked on top of it,
+ * and the two decisions they can make about it.
+ *
+ * The review is deliberately a diff rather than a preview of the result — an
+ * editor has to be able to tell what would change, including that a field they
+ * care about would be emptied.
+ */
+
+const CURRENT_SPEC: ListingFixtureOverrides = {
+  id: 12,
+  title: 'Bike Kitchen',
+  description: 'Volunteers help you fix your own bicycle.',
+  website: 'https://bikekitchen.org',
+  tags: [
+    { id: 1, label: 'Volunteer-run' },
+    { id: 2, label: 'Free' },
+  ],
+  socials: [
+    { platform: 'instagram', url: 'https://instagram.com/bikekitchen' },
+  ],
+  actions: [{ type: 'donate', url: 'https://bikekitchen.org/donate' }],
+}
+
+const CURRENT = listing(CURRENT_SPEC)
+
+/** The listing as the suggestion would leave it. */
+const suggesting = (changes: ListingFixtureOverrides) =>
+  listing({ ...CURRENT_SPEC, ...changes })
+
+function renderReview(editedListing: Listing, { onAccept = vi.fn() } = {}) {
+  return {
+    onAccept,
+    ...renderPage(
+      <ListingEditReview
+        listing={CURRENT}
+        editedListing={editedListing}
+        handleSubmit={onAccept}
+        webSlug="bristol"
+      />,
+    ),
+  }
+}
+
+/** A field's section, found by the heading the review gives it. */
+const section = (label: string) =>
+  screen.getByRole('heading', { name: label }).parentElement
+
+describe('the suggested-edit review', () => {
+  it('shows the old and the new wording side by side', () => {
+    renderReview(
+      suggesting({
+        title: 'Bristol Bike Kitchen',
+        description: 'Volunteers help you fix your own bicycle every Sunday.',
+      }),
+    )
+
+    expect(section('Title')).toHaveTextContent('Bristol')
+    expect(section('Title')).toHaveTextContent('Bike Kitchen')
+    expect(section('Description')).toHaveTextContent('every Sunday')
+  })
+
+  it('leaves out the fields the suggestion does not touch', () => {
+    renderReview(suggesting({ title: 'Bristol Bike Kitchen' }))
+
+    expect(screen.getByRole('heading', { name: 'Title' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Description' })).toBeNull()
+    expect(screen.queryByRole('heading', { name: 'Website' })).toBeNull()
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Contact email for organisation',
+      }),
+    ).toBeNull()
+  })
+
+  it('spells out that a field would be emptied', () => {
+    renderReview(suggesting({ website: '' }))
+
+    expect(section('Website')).toHaveTextContent('https://bikekitchen.org')
+    expect(section('Website')).toHaveTextContent('(deleted)')
+  })
+
+  it('shows which tags would be added, removed and left alone', () => {
+    renderReview(
+      suggesting({
+        tags: [
+          { id: 1, label: 'Volunteer-run' },
+          { id: 5, label: 'Repair' },
+        ],
+      }),
+    )
+
+    expect(section('Tags')).toHaveTextContent('Added:+ Repair')
+    expect(section('Tags')).toHaveTextContent('Removed:Free')
+    expect(section('Tags')).toHaveTextContent('Unchanged:Volunteer-run')
+  })
+
+  it('says nothing about tags when they are untouched', () => {
+    renderReview(suggesting({ title: 'Bristol Bike Kitchen' }))
+
+    expect(screen.queryByRole('heading', { name: 'Tags' })).toBeNull()
+  })
+
+  it('shows a social media link that would be replaced', () => {
+    renderReview(
+      suggesting({
+        socials: [
+          { platform: 'instagram', url: 'https://instagram.com/bristolbikes' },
+        ],
+      }),
+    )
+
+    expect(
+      screen.getByText('https://instagram.com/bikekitchen'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('https://instagram.com/bristolbikes'),
+    ).toBeInTheDocument()
+  })
+
+  it('marks a social media link that would be dropped as removed', () => {
+    renderReview(suggesting({ socials: [] }))
+
+    expect(screen.getByText('(removed)')).toBeInTheDocument()
+    expect(
+      screen.getByText('https://instagram.com/bikekitchen'),
+    ).toBeInTheDocument()
+  })
+
+  it('marks a new action button as added', () => {
+    renderReview(
+      suggesting({
+        actions: [
+          { type: 'donate', url: 'https://bikekitchen.org/donate' },
+          { type: 'volunteer', url: 'https://bikekitchen.org/volunteer' },
+        ],
+      }),
+    )
+
+    expect(
+      screen.getByText('https://bikekitchen.org/volunteer'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('(added)')).toBeInTheDocument()
+  })
+})
+
+describe('deciding on a suggested edit', () => {
+  it('applies the suggestion when the editor accepts it', async () => {
+    const { user, onAccept } = renderReview(
+      suggesting({ title: 'Bristol Bike Kitchen' }),
+    )
+
+    await user.click(screen.getByRole('button', { name: /accept changes/i }))
+
+    expect(onAccept).toHaveBeenCalled()
+  })
+
+  it('throws the suggestion away when the editor rejects it', async () => {
+    const rejected = recordRequests({})
+    server.use(http.delete('/api/listings/:slug/edit', rejected.resolver))
+
+    const { user, onAccept } = renderReview(
+      suggesting({ title: 'Bristol Bike Kitchen' }),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
+
+    await waitFor(() => expect(rejected.calls).toHaveLength(1))
+    expect(rejected.calls[0].url.pathname).toBe(
+      '/api/listings/bike-kitchen/edit',
+    )
+    expect(rejected.calls[0].url.searchParams.get('web')).toBe('bristol')
+    expect(onAccept).not.toHaveBeenCalled()
+    expect(router.back).toHaveBeenCalled()
+  })
+})

--- a/components/import/__tests__/ImportWizard.test.tsx
+++ b/components/import/__tests__/ImportWizard.test.tsx
@@ -1,0 +1,300 @@
+import { recordRequests } from '@/test/msw/handlers'
+import { server } from '@/test/msw/server'
+import { renderPage } from '@/test/render'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+import { ImportWizard } from '../ImportWizard'
+
+/**
+ * The four-step wizard a web editor uses to bring a spreadsheet of groups into
+ * their web: upload, map the columns onto listing fields, review what will be
+ * created, import.
+ *
+ * The wizard is a gate as much as a form — the point of the middle two steps is
+ * that nothing reaches the database until the columns make sense and every row
+ * validates. So most of what is tested here is what it refuses to do.
+ */
+
+function csv(...lines: string[]) {
+  return new File([lines.join('\n')], 'groups.csv', { type: 'text/csv' })
+}
+
+const TWO_GOOD_ROWS = csv(
+  'Name,Description,Category,Website',
+  'Bike Kitchen,Volunteers help you fix your own bicycle,Transport,https://bikekitchen.org',
+  'Repair Cafe,Bring something broken and mend it,Community,https://repaircafe.org',
+)
+
+function renderWizard() {
+  const rendered = renderPage(<ImportWizard webSlug="bristol" webId={3} />, {
+    selectedWeb: { slug: 'bristol', id: 3 },
+  })
+
+  /**
+   * The upload zone is a drop target with a transparent file input stretched
+   * over it, so there is nothing else to hand the file to.
+   */
+  const fileInput = () =>
+    rendered.container.querySelector<HTMLInputElement>('input[type="file"]')
+
+  const dropZone = () => fileInput().parentElement
+
+  return { ...rendered, fileInput, dropZone }
+}
+
+const next = (user: ReturnType<typeof renderPage>['user']) =>
+  user.click(screen.getByRole('button', { name: /next/i }))
+
+/** Uploads a file and waits for the wizard to be ready to move on. */
+async function upload(
+  { user, fileInput }: ReturnType<typeof renderWizard>,
+  file: File,
+) {
+  await user.upload(fileInput(), file)
+  await screen.findByText(file.name)
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled(),
+  )
+}
+
+/** The row of the mapping table for one CSV column. */
+const mappingFor = (header: string) =>
+  screen.getByRole('row', { name: new RegExp(`^${header}\\b`) })
+
+describe('the CSV import wizard', () => {
+  it('will not move past the first step until a file is chosen', () => {
+    renderWizard()
+
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+
+  it('names the chosen file back to the editor', async () => {
+    const wizard = renderWizard()
+
+    await upload(wizard, TWO_GOOD_ROWS)
+
+    expect(screen.getByText('groups.csv')).toBeInTheDocument()
+  })
+
+  it('takes a file dropped onto the upload zone', async () => {
+    const { dropZone } = renderWizard()
+
+    fireEvent.drop(dropZone(), {
+      dataTransfer: { files: [TWO_GOOD_ROWS] },
+    })
+
+    expect(await screen.findByText('groups.csv')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeEnabled(),
+    )
+  })
+
+  it('ignores a dropped file that is not a CSV', () => {
+    const { dropZone } = renderWizard()
+
+    fireEvent.drop(dropZone(), {
+      dataTransfer: {
+        files: [new File(['nope'], 'groups.txt', { type: 'text/plain' })],
+      },
+    })
+
+    expect(screen.queryByText('groups.txt')).toBeNull()
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+})
+
+describe('mapping the columns', () => {
+  it('recognises the columns it can and shows what they hold', async () => {
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+
+    expect(
+      await screen.findByRole('columnheader', { name: 'Maps to' }),
+    ).toBeInTheDocument()
+    expect(mappingFor('Name')).toHaveTextContent('Name (required)')
+    expect(mappingFor('Website')).toHaveTextContent('Website')
+    // The first rows are shown alongside, so the editor can check the guess.
+    expect(mappingFor('Name')).toHaveTextContent('Bike Kitchen')
+  })
+
+  it('blocks the import while a required field is unmapped', async () => {
+    const wizard = renderWizard()
+    await upload(
+      wizard,
+      csv(
+        'Name,Blurb,Category',
+        'Bike Kitchen,Volunteers help you fix your own bicycle,Transport',
+      ),
+    )
+    await next(wizard.user)
+
+    expect(
+      await screen.findByText(/required fields not mapped/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+
+  it('lets the editor map an unrecognised column by hand', async () => {
+    const wizard = renderWizard()
+    await upload(
+      wizard,
+      csv(
+        'Name,Blurb,Category',
+        'Bike Kitchen,Volunteers help you fix your own bicycle,Transport',
+      ),
+    )
+    await next(wizard.user)
+
+    await wizard.user.click(within(mappingFor('Blurb')).getByRole('combobox'))
+    await wizard.user.click(
+      await screen.findByRole('option', { name: 'Description' }),
+    )
+
+    expect(screen.queryByText(/required fields not mapped/i)).toBeNull()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeEnabled(),
+    )
+  })
+
+  it('lets the editor drop a column they do not want imported', async () => {
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+
+    await wizard.user.click(within(mappingFor('Website')).getByRole('combobox'))
+    await wizard.user.click(
+      await screen.findByRole('option', { name: /don't import/i }),
+    )
+
+    expect(mappingFor('Website')).toHaveTextContent("(Don't import)")
+  })
+})
+
+describe('reviewing before importing', () => {
+  it('says every row is good and previews what would be created', async () => {
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+    await next(wizard.user)
+
+    expect(await screen.findByText(/all rows valid/i)).toBeInTheDocument()
+    expect(screen.getByText('Bike Kitchen')).toBeInTheDocument()
+    expect(screen.getByText('Repair Cafe')).toBeInTheDocument()
+  })
+
+  it('refuses to import while a row is invalid, and says which', async () => {
+    const wizard = renderWizard()
+    await upload(
+      wizard,
+      csv(
+        'Name,Description,Category,Email',
+        'Bike Kitchen,Volunteers help you fix your own bicycle,Transport,hello@bikekitchen.org',
+        'Repair Cafe,,Community,nope',
+      ),
+    )
+    await next(wizard.user)
+    await next(wizard.user)
+
+    expect(
+      await screen.findByText(/validation errors found/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /start import/i })).toBeDisabled()
+
+    await wizard.user.click(
+      screen.getByRole('button', { name: /show error details/i }),
+    )
+
+    expect(await screen.findByText(/Row 2:/)).toBeInTheDocument()
+    expect(screen.getByText(/description is required/i)).toBeInTheDocument()
+    expect(screen.getByText(/invalid email address/i)).toBeInTheDocument()
+    // The valid row is not held up as a problem.
+    expect(screen.queryByText(/Row 1:/)).toBeNull()
+  })
+})
+
+describe('running the import', () => {
+  const summaryOf = (rows: number) => ({
+    success: true,
+    summary: {
+      totalRows: rows,
+      successCount: rows,
+      errorCount: 0,
+      skipCount: 0,
+      batches: [],
+      completedAt: '2026-03-09T12:00:00.000Z',
+    },
+  })
+
+  it('sends the mapped rows to the web being imported into', async () => {
+    const imported = recordRequests(summaryOf(2))
+    server.use(http.post('/api/listings/import', imported.resolver))
+
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+    await next(wizard.user)
+    await wizard.user.click(
+      await screen.findByRole('button', { name: /start import/i }),
+    )
+
+    await waitFor(() => expect(imported.calls).toHaveLength(1))
+    expect(imported.calls[0].url.searchParams.get('web')).toBe('bristol')
+    expect(imported.calls[0].body).toMatchObject({
+      webId: 3,
+      columnMapping: {
+        Name: 'name',
+        Description: 'description',
+        Category: 'category',
+        Website: 'website',
+      },
+    })
+    expect(imported.calls[0].body.rows).toHaveLength(2)
+  })
+
+  it('reports the outcome once it is done', async () => {
+    const imported = recordRequests(summaryOf(2))
+    server.use(http.post('/api/listings/import', imported.resolver))
+
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+    await next(wizard.user)
+    await wizard.user.click(
+      await screen.findByRole('button', { name: /start import/i }),
+    )
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /import completed successfully/i,
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /view listings/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('leaves the editor on the review step when the import fails', async () => {
+    server.use(
+      http.post('/api/listings/import', () =>
+        HttpResponse.json({ error: 'Something went wrong' }, { status: 500 }),
+      ),
+    )
+
+    const wizard = renderWizard()
+    await upload(wizard, TWO_GOOD_ROWS)
+    await next(wizard.user)
+    await next(wizard.user)
+    await wizard.user.click(
+      await screen.findByRole('button', { name: /start import/i }),
+    )
+
+    expect(
+      await screen.findByRole('button', { name: /start import/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /import completed/i }),
+    ).toBeNull()
+  })
+})

--- a/test/fixtures/listing.ts
+++ b/test/fixtures/listing.ts
@@ -1,0 +1,88 @@
+/**
+ * A listing in the shape the client sees it — what `/api/listings` returns and
+ * what the admin screens and the edit form are given as props.
+ *
+ * Tests name only the fields they are about; everything else is a plausible
+ * default, so a test reads as the one thing it is checking.
+ */
+
+export interface CategoryFixture {
+  id: number
+  label: string
+  color: string
+  icon: string
+}
+
+export interface ListingFixtureOverrides {
+  id?: number
+  title?: string
+  slug?: string
+  description?: string
+  category?: Partial<CategoryFixture>
+  email?: string
+  website?: string
+  image?: string | null
+  socials?: { platform: string; url: string }[]
+  actions?: { type: string; url: string }[]
+  tags?: { id: number; label: string }[]
+  location?: {
+    latitude?: number
+    longitude?: number
+    description?: string
+    noPhysicalLocation?: boolean
+  } | null
+  /** Set by the admin table's star; a date in the future means featured. */
+  featured?: string | null
+  /** True while a proposed listing is waiting for an editor to approve it. */
+  pending?: boolean
+  inactive?: boolean
+  /** Suggested edits awaiting review. */
+  edits?: unknown[]
+  createdAt?: string
+  updatedAt?: string
+  sharedWith?: unknown[]
+}
+
+const DEFAULT_CATEGORY: CategoryFixture = {
+  id: 4,
+  label: 'Community',
+  color: 'b0e3c1',
+  icon: 'default',
+}
+
+/**
+ * The `Listing` type describes the Prisma row, where dates are `Date` objects
+ * and the relations carry every column. What the client actually receives is
+ * JSON — dates as strings, relations trimmed to what the screen needs — which
+ * is what this builds, so it is handed over as a `Listing` at the boundary.
+ */
+export function listing(overrides: ListingFixtureOverrides = {}): Listing {
+  const title = overrides.title ?? 'Bike Kitchen'
+
+  return {
+    id: 1,
+    title,
+    slug: slugify(title),
+    description: 'A workshop where volunteers help you fix your own bicycle.',
+    email: 'hello@bikekitchen.org',
+    website: 'https://bikekitchen.org',
+    image: null,
+    socials: [],
+    actions: [],
+    tags: [],
+    location: null,
+    featured: null,
+    pending: false,
+    inactive: false,
+    edits: [],
+    createdAt: '2026-01-05T10:00:00.000Z',
+    updatedAt: '2026-02-11T10:00:00.000Z',
+    sharedWith: [],
+    ...overrides,
+    category: { ...DEFAULT_CATEGORY, ...overrides.category },
+  } as unknown as Listing
+}
+
+function slugify(title: string) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+}

--- a/test/msw/handlers.ts
+++ b/test/msw/handlers.ts
@@ -17,11 +17,14 @@ export interface CategoryStub {
   label: string
   color?: string
   icon?: string
+  _count?: { listings: number }
 }
 
 export interface TagStub {
   id: number
   label: string
+  listings?: unknown[]
+  _count?: { listings: number }
 }
 
 export const handlers = [
@@ -45,4 +48,85 @@ export function stubCategories(categories: CategoryStub[]) {
 /** Tags as `/api/tags?web=…` returns them. */
 export function stubTags(tags: TagStub[]) {
   return http.get('/api/tags', () => HttpResponse.json({ data: tags }))
+}
+
+/** Listings as `/api/listings?web=…` returns them. */
+export function stubListings(listings: unknown[]) {
+  return http.get('/api/listings', () => HttpResponse.json({ listings }))
+}
+
+/** A single web, as `/api/webs/:slug` returns it. */
+export function stubWeb(web: { id?: number; title?: string; slug?: string }) {
+  return http.get('/api/webs/:slug', ({ params }) =>
+    HttpResponse.json({
+      web: { id: 1, title: 'Bristol', slug: params.slug, ...web },
+    }),
+  )
+}
+
+/**
+ * The answer to "may the signed-in user edit this web?", which the admin
+ * screens ask before showing anything that changes it.
+ */
+export function stubCanEditWeb(canEdit: boolean) {
+  return http.get('/api/web-access/check', () => HttpResponse.json({ canEdit }))
+}
+
+/** Pending edits for a listing, as `/api/listings/:slug/edit?web=…` returns them. */
+export function stubListingEdits(listingEdits: unknown[]) {
+  return http.get('/api/listings/:slug/edit', () =>
+    HttpResponse.json({ listingEdits }),
+  )
+}
+
+export interface RecordedRequest {
+  url: URL
+  /** JSON bodies as-is; form submissions as a plain object of their fields. */
+  body: Record<string, unknown>
+}
+
+export interface RequestRecorder {
+  /** Every matching request the component made, in the order it made them. */
+  calls: RecordedRequest[]
+  /** Pass to `http.post(path, recorder.resolver)`. */
+  resolver: (info: { request: Request }) => Promise<Response>
+}
+
+/**
+ * Stubs a request and remembers what was sent, so a test can assert on the
+ * change a component asked the server to make:
+ *
+ *   const created = recordRequests({ listing: { slug: 'bike-kitchen' } })
+ *   server.use(http.post('/api/listings', created.resolver))
+ *   …
+ *   await waitFor(() => expect(created.calls).toHaveLength(1))
+ *   expect(created.calls[0].body).toMatchObject({ title: 'Bike Kitchen' })
+ */
+export function recordRequests(respondWith: unknown = {}): RequestRecorder {
+  const calls: RecordedRequest[] = []
+
+  return {
+    calls,
+    resolver: async ({ request }) => {
+      calls.push({
+        url: new URL(request.url),
+        body: await readBody(request),
+      })
+      return HttpResponse.json(respondWith)
+    },
+  }
+}
+
+async function readBody(request: Request): Promise<Record<string, unknown>> {
+  const contentType = request.headers.get('content-type') ?? ''
+
+  if (contentType.includes('application/json')) {
+    return (await request.json()) as Record<string, unknown>
+  }
+
+  if (contentType.includes('multipart/form-data')) {
+    return Object.fromEntries(await request.formData())
+  }
+
+  return {}
 }

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -3,16 +3,29 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, type RenderOptions } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+import { AppContext } from '@store/AppContext'
+
+/**
+ * The web an admin screen is currently working on. In the app this comes from
+ * `StoreProvider`, which remembers the choice in local storage; the components
+ * only ever read it through `useAppContext`.
+ */
+export interface SelectedWeb {
+  slug?: string
+  id?: number
+}
 
 /**
  * Renders a component the way the app does, so tests can drive it as a user.
  *
- * Provides the two things these components need from their surroundings and
+ * Provides the things these components need from their surroundings and
  * nothing else:
  *  - React Query, so data-fetching hooks are real (see `test/msw` for the
  *    responses they get)
  *  - nuqs, so components that keep state in the URL work; pass `searchParams`
  *    to start the test on a particular URL state
+ *  - the selected web, which every admin screen reads to know what it is
+ *    looking at; pass `selectedWeb` to put a test inside one
  *
  * Retries are off, otherwise a deliberately-failing request takes three
  * attempts before the component shows its error state.
@@ -21,18 +34,28 @@ export function renderPage(
   ui: ReactElement,
   {
     searchParams = {},
+    selectedWeb = {},
     ...options
   }: Omit<RenderOptions, 'wrapper'> & {
     searchParams?: Record<string, string>
+    selectedWeb?: SelectedWeb
   } = {},
 ) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
 
+  const appContext = {
+    selectedWebSlug: selectedWeb.slug,
+    selectedWebId: selectedWeb.id,
+    setSelectedWebSlug: () => {},
+  }
+
   const Providers = ({ children }: { children: ReactNode }) => (
     <NuqsTestingAdapter searchParams={searchParams}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <AppContext value={appContext}>{children}</AppContext>
+      </QueryClientProvider>
     </NuqsTestingAdapter>
   )
 

--- a/test/session.ts
+++ b/test/session.ts
@@ -1,9 +1,10 @@
 /**
- * Controls the session that route handlers see.
+ * Controls who is signed in, for both test suites.
  *
- * Route handlers call `getSessionSafe()` from `@auth`; integration tests mock
- * that module (see `setup/external-mocks.ts`) to read from this store, so a
- * test can switch identity with `signInAs()` without re-mocking anything.
+ * Route handlers call `getSessionSafe()` from `@auth`, and components call
+ * `useSession()` from `@auth-client`. Each suite's setup file mocks its own
+ * side to read from this store, so either kind of test switches identity with
+ * `signInAs()` without re-mocking anything.
  */
 
 export interface TestSessionUser {

--- a/test/setup/components.tsx
+++ b/test/setup/components.tsx
@@ -3,6 +3,7 @@ import { cleanup } from '@testing-library/react'
 import { afterAll, afterEach, beforeAll, vi } from 'vitest'
 import { server } from '../msw/server.ts'
 import { resetRoute, route, router } from '../next-navigation.ts'
+import { signOut } from '../session.ts'
 
 // Components read the current route from `next/navigation`, which has no
 // implementation under jsdom. Backed by `test/next-navigation.ts` so a test can
@@ -52,6 +53,54 @@ vi.mock('next/navigation', () => ({
   notFound: vi.fn(),
 }))
 
+// Better Auth keeps the session in the browser and there is no browser here,
+// so `useSession` reads from `test/session.ts` instead — the same store the
+// integration tests drive with `signInAs()`. This and `next/navigation` above
+// are the only two places the component suite knows what it is running on.
+vi.mock('@auth-client', async () => {
+  const { sessionStore } = await import('../session.ts')
+  return {
+    useSession: () => ({
+      data: sessionStore.current,
+      isPending: false,
+      error: null,
+    }),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    authClient: {},
+    ERROR_MESSAGES: {},
+  }
+})
+
+// TinyMCE downloads its editor from a CDN and takes over a real document to
+// render into. It stands in for a text box, so that is what it renders as here
+// — a test types a description the same way a visitor does. The remaining props
+// are the id and labelling that `FormControl` hands down, so the field keeps
+// its accessible name.
+vi.mock('@tinymce/tinymce-react', () => ({
+  Editor: ({
+    value,
+    onEditorChange,
+    onBlur,
+    apiKey: _apiKey,
+    init: _init,
+    ...rest
+  }: Record<string, any>) => (
+    <textarea
+      {...rest}
+      value={value ?? ''}
+      onBlur={onBlur}
+      onChange={(event) => onEditorChange?.(event.target.value)}
+    />
+  ),
+}))
+
+// Analytics is an outbound edge: tests drive real user journeys and must not
+// report them anywhere.
+vi.mock('posthog-js', () => ({
+  default: { capture: vi.fn(), init: vi.fn(), identify: vi.fn() },
+}))
+
 // `error` so a request the tests forgot to stub fails loudly instead of
 // silently resolving to something unexpected.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
@@ -60,6 +109,7 @@ afterEach(() => {
   cleanup()
   server.resetHandlers()
   resetRoute()
+  signOut()
 })
 
 afterAll(() => server.close())
@@ -105,6 +155,10 @@ if (!globalThis.IntersectionObserver) {
   } as unknown as typeof IntersectionObserver
 }
 /* eslint-enable no-empty-function */
+
+// jsdom defines scrollTo but throws from it, so this one is replaced outright
+// rather than filled in.
+window.scrollTo = vi.fn()
 
 /* eslint-disable @typescript-eslint/unbound-method -- assigning stubs onto the
    prototype is the point here; nothing is being detached and called. */


### PR DESCRIPTION
Closes #515. Follows #510, which set up the component-test pattern but only applied it to the web page's search and category filtering.

66 tests covering the six flows the issue lists. `npm run test` is 240 passing; `npm run test:integration` is unchanged at 129.

## What's covered

| Flow | File | Covers |
|---|---|---|
| Proposing a listing | `app/new-listing/[webSlug]/__tests__/NewListing.test.tsx` | required fields, invalid URL, slug derived from title, what the POST actually carries (`pending`, `webId`, proposer), thank-you screen |
| Editing a listing | `app/edit/[webSlug]/[listingSlug]/__tests__/EditListing.test.tsx` | form arrives prefilled, address can't move, suggestion posted against the right listing and web, the "already under review" block |
| Reviewing a pending edit | `components/admin/listing-form/listing-edit-review/__tests__/ListingEditReview.test.tsx` | old and new shown side by side, untouched fields omitted, emptied field called out, tag add/remove/unchanged, socials and actions, accept, reject |
| CSV import wizard | `components/import/__tests__/ImportWizard.test.tsx` | upload and drop, auto-detected mapping, blocking on unmapped required fields, manual mapping, the validation gate with per-row errors, the request sent, results screen, failure returning to review |
| Admin listings table | `components/admin/editable-list/__tests__/EditableList.test.tsx` | search, category filter (including from the URL), attention-first ordering, pending and suggested-edit badges, feature and unfeature (including expired dates), delete confirmation, shared-listing wording, no controls without edit rights |
| Tags and categories | `app/admin/categories/__tests__/page.test.tsx` | create (capitalisation, `webId`), rename, delete, and the "can't delete while in use" rule for both |

## Verifying each test fails for the right reason

As the issue asks. I broke the behaviour behind 28 of these and confirmed each went red — the mapping gate, the validation gate, the search and category filters, the attention-first ordering, the feature/unfeature toggle, the delete confirmation, the edit-rights check, the diff's "only changed fields" rule, the delete-while-in-use rules, and the rest.

Two versions passed at first for a bad reason and were rewritten:

- a "not a CSV" upload the browser's `accept` filter makes unreachable through the file input — it is now tested through the drop target, which is the only path that reaches it
- an "invalid website" row that `sanitizeUrl` silently repairs into a valid URL, so the row was never actually invalid

## Test infrastructure

- `renderPage` takes `selectedWeb`, which every admin screen reads through `useAppContext`
- new MSW helpers `stubListings`, `stubWeb`, `stubListingEdits`, `stubCanEditWeb`, plus `recordRequests()`, which stubs a request and remembers the URL and body (JSON or form) so a test can assert on the change a component asked the server to make
- `test/fixtures/listing.ts` — `listing({ title })` in the shape the client sees it
- the setup file now also stubs the modules with no implementation under jsdom: `@auth-client` (reads from `test/session.ts`, so `signInAs()` works in both suites), `@tinymce/tinymce-react` (renders as the text box it stands in for) and `posthog-js`
- Testing section of AGENTS.md updated to match

## Two app changes the tests forced

Both are real accessibility defects — each left a control with no accessible name, so a screen-reader user can't operate it either:

- `ListingFormSimplified.tsx` — the "Link to listing page" label pointed at nothing; its input is now wrapped in `FormControl`
- `editable-list/table/Table.tsx` — the feature star was an icon-only button with no accessible name; added `aria-label`

## Steps to test

```bash
npm run test              # unit + component
npm run test:integration  # unchanged, still green
npm run quality:dry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
