### PR TITLE
perf: cut client bundle and per-visitor requests on public pages

### DIFF
--- a/app/PostHogPageView.tsx
+++ b/app/PostHogPageView.tsx
@@ -1,13 +1,81 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
-import { usePostHog } from 'posthog-js/react'
+import type { PostHog } from 'posthog-js'
+
+/**
+ * Boots PostHog and reports page views.
+ *
+ * `posthog-js` is ~82 KiB gzipped and analytics is never on the critical path,
+ * so it is imported on idle rather than statically from the root providers,
+ * which put it in the entry chunk of every page.
+ */
+
+let clientPromise: Promise<PostHog | null> | null = null
+
+function loadPostHog(): Promise<PostHog | null> {
+  if (clientPromise) return clientPromise
+
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  if (!key) {
+    clientPromise = Promise.resolve(null)
+    return clientPromise
+  }
+
+  clientPromise = import('posthog-js')
+    .then(({ default: posthog }) => {
+      posthog.init(key, {
+        api_host:
+          process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
+        ui_host: 'https://eu.posthog.com',
+        debug: false,
+        capture_pageview: false,
+        capture_pageleave: true,
+        persistence: 'localStorage',
+        capture_exceptions: true,
+        capture_performance: true,
+        session_recording: {
+          maskAllInputs: false,
+        },
+      })
+      return posthog
+    })
+    .catch(() => null)
+
+  return clientPromise
+}
+
+function whenIdle(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+
+  if (typeof window.requestIdleCallback === 'function') {
+    const handle = window.requestIdleCallback(callback, { timeout: 5000 })
+    return () => window.cancelIdleCallback(handle)
+  }
+  const timeout = window.setTimeout(callback, 2000)
+  return () => window.clearTimeout(timeout)
+}
 
 export default function PostHogPageView() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const posthog = usePostHog()
+  const [posthog, setPosthog] = useState<PostHog | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const cancelIdle = whenIdle(() => {
+      void loadPostHog().then((client) => {
+        if (!cancelled) setPosthog(client)
+        return client
+      })
+    })
+    return () => {
+      cancelled = true
+      cancelIdle()
+    }
+  }, [])
+
   useEffect(() => {
     // Track pageviews
     if (pathname && posthog) {

--- a/app/[subdomain]/Web.tsx
+++ b/app/[subdomain]/Web.tsx
@@ -59,7 +59,6 @@ export type WebTag = { id: number; label: string }
 type Props = {
   // gzip+base64 compressed NetworkData, decompressed on the client below.
   data: string
-  /** Every category and every in-use tag in this web, from the server render. */
   categories?: WebCategory[]
   tags?: WebTag[]
   events?: any[]

--- a/app/[subdomain]/Web.tsx
+++ b/app/[subdomain]/Web.tsx
@@ -25,8 +25,6 @@ import MainList from '@components/main-list'
 import { Button } from '@components/ui/button'
 import { Spinner } from '@components/ui/spinner'
 import useIsMobile from '@hooks/application/useIsMobile'
-import useCategoriesPublic from '@hooks/categories/useCategoriesPublic'
-import useTagsPublic from '@hooks/tags/useTagsPublic'
 
 const NetworkComponent = dynamic(() => import('@components/network'), {
   ssr: false,
@@ -55,9 +53,15 @@ export type RelatedWeb = {
   }
 }
 
+export type WebCategory = { label: string; color: string; icon: string }
+export type WebTag = { id: number; label: string }
+
 type Props = {
   // gzip+base64 compressed NetworkData, decompressed on the client below.
   data: string
+  /** Every category and every in-use tag in this web, from the server render. */
+  categories?: WebCategory[]
+  tags?: WebTag[]
   events?: any[]
   features: any
   webId: number
@@ -72,6 +76,8 @@ type Props = {
 
 const Web = ({
   data: compressedData,
+  categories: webCategories = [],
+  tags: webTags = [],
   events,
   features,
   webId,
@@ -136,12 +142,8 @@ const Web = ({
   const handleSearchTermChange = (event) => setSearchTerm(event.target.value)
   const handleClearSearchTermValue = () => setSearchTerm('')
 
-  const { categories: fetchedCategories } = useCategoriesPublic({ webSlug })
-  const { tags: fetchedTags } = useTagsPublic({ webSlug })
-
   const categories = (() => {
-    if (!fetchedCategories) return []
-    return fetchedCategories.map((c) => {
+    return webCategories.map((c) => {
       const color = `#${c.color}`
       const IconComponent =
         c.icon && c.icon !== 'default' ? getIcon(c.icon)?.icon : undefined
@@ -156,8 +158,7 @@ const Web = ({
   })()
 
   const tags = (() => {
-    if (!fetchedTags) return []
-    return fetchedTags.map((t) => ({
+    return webTags.map((t) => ({
       value: t.label,
       label: t.label,
     }))
@@ -409,13 +410,17 @@ const Web = ({
           ))}
 
         {activeTab === 'list' && (
-          <MainList filteredItems={filteredItems} webSlug={webSlug} />
+          <MainList
+            filteredItems={filteredItems}
+            webSlug={webSlug}
+            categories={webCategories}
+          />
         )}
         {activeTab === 'map' && (
           <ListingsMap
             items={filteredItems}
-            webSlug={webSlug}
             relatedWebs={relatedWebs}
+            categories={webCategories}
           />
         )}
         {activeTab === 'events' && <Events items={events} webSlug={webSlug} />}

--- a/app/[subdomain]/[slug]/Listing.tsx
+++ b/app/[subdomain]/[slug]/Listing.tsx
@@ -5,7 +5,7 @@ import ListingDisplay from '@components/listing'
 export default function Listing({ listing }) {
   return (
     <Layout>
-      <ListingDisplay listing={listing} />
+      <ListingDisplay listing={listing} categories={listing.web?.categories} />
     </Layout>
   )
 }

--- a/app/[subdomain]/[slug]/getListing.ts
+++ b/app/[subdomain]/[slug]/getListing.ts
@@ -36,8 +36,6 @@ export default async function getListing({
       },
     },
     include: {
-      // `categories` rides along on the existing join rather than costing a
-      // /api/categories request per visitor to this otherwise static page.
       web: {
         select: {
           id: true,

--- a/app/[subdomain]/[slug]/getListing.ts
+++ b/app/[subdomain]/[slug]/getListing.ts
@@ -2,6 +2,17 @@ import prisma from '@prisma-rw'
 import { exclude } from '@helpers/utils'
 import { isBuildTime, getListingFromCache } from '../../../lib/build-cache'
 
+/** Label-sorted, as the client hook sorted them. See `getData` in the web page. */
+export function sortCategoriesByLabel<T extends { label: string }>(
+  categories: T[] = [],
+): T[] {
+  return [...categories].sort((a, b) => {
+    if (a.label < b.label) return -1
+    if (a.label > b.label) return 1
+    return 0
+  })
+}
+
 export default async function getListing({
   webSlug,
   listingSlug,
@@ -25,7 +36,16 @@ export default async function getListing({
       },
     },
     include: {
-      web: { select: { id: true, slug: true, title: true } },
+      // `categories` rides along on the existing join rather than costing a
+      // /api/categories request per visitor to this otherwise static page.
+      web: {
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          categories: { select: { label: true } },
+        },
+      },
       category: { select: { id: true, color: true, label: true, icon: true } },
       tags: { select: { id: true, label: true } },
       listing: {
@@ -84,7 +104,10 @@ export default async function getListing({
     featured: placementFields.featured,
     category: placementFields.category,
     tags: placementFields.tags,
-    web: placementFields.web,
+    web: {
+      ...placementFields.web,
+      categories: sortCategoriesByLabel(placementFields.web.categories),
+    },
     alsoListedIn: alsoIn.map((p) => ({
       slug: p.slug,
       web: p.web,

--- a/app/[subdomain]/[slug]/page.tsx
+++ b/app/[subdomain]/[slug]/page.tsx
@@ -4,7 +4,7 @@ import truncate from 'lodash.truncate'
 import prisma from '@prisma-rw-build'
 import { initializeBuildCache } from '../../../lib/build-cache'
 import Listing from './Listing'
-import getListing from './getListing'
+import getListing, { sortCategoriesByLabel } from './getListing'
 
 type PageProps = {
   params: Promise<{
@@ -74,7 +74,13 @@ export async function generateStaticParams() {
       listing: { inactive: false },
     },
     include: {
-      web: { select: { slug: true, title: true } },
+      web: {
+        select: {
+          slug: true,
+          title: true,
+          categories: { select: { label: true } },
+        },
+      },
       category: { select: { id: true, color: true, label: true, icon: true } },
       tags: { select: { id: true, label: true } },
       listing: {
@@ -100,7 +106,10 @@ export async function generateStaticParams() {
     featured: p.featured,
     category: p.category,
     tags: p.tags,
-    web: p.web,
+    web: {
+      ...p.web,
+      categories: sortCategoriesByLabel(p.web.categories),
+    },
   }))
   initializeBuildCache(flattenedForCache as any)
 

--- a/app/[subdomain]/__tests__/Web.filtering.test.tsx
+++ b/app/[subdomain]/__tests__/Web.filtering.test.tsx
@@ -1,12 +1,19 @@
 import { webData } from '@/test/fixtures/web'
-import { stubCategories, stubTags } from '@/test/msw/handlers'
-import { server } from '@/test/msw/server'
 import { renderPage } from '@/test/render'
 import { screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import Web from '../Web.tsx'
 
 vi.mock('@helpers/analytics', () => ({ trackWebEvent: vi.fn() }))
+
+/** The server has these when it renders, so the filters never fetch them. */
+const CATEGORIES = [
+  { label: 'Community', color: 'b0e3c1', icon: 'default' },
+  { label: 'Environment', color: 'b0e3c1', icon: 'default' },
+  { label: 'Transportation', color: 'b0e3c1', icon: 'default' },
+]
+
+const TAGS = [{ id: 1, label: 'Volunteer-run' }]
 
 const LISTINGS = [
   { title: 'Community Kitchen', category: 'Community' },
@@ -20,6 +27,8 @@ function renderWeb() {
   return renderPage(
     <Web
       data={webData(LISTINGS)}
+      categories={CATEGORIES}
+      tags={TAGS}
       features={[]}
       webId={1}
       webName="Bristol"
@@ -53,17 +62,6 @@ const expectHidden = (titles: string[]) =>
   )
 
 const ALL_TITLES = LISTINGS.map((l) => l.title)
-
-beforeEach(() => {
-  server.use(
-    stubCategories([
-      { id: 1, label: 'Community' },
-      { id: 2, label: 'Environment' },
-      { id: 3, label: 'Transportation' },
-    ]),
-    stubTags([{ id: 1, label: 'Volunteer-run' }]),
-  )
-})
 
 describe('the web page listing filters', () => {
   it('shows every listing before anything is filtered', async () => {
@@ -101,6 +99,8 @@ describe('the web page listing filters', () => {
             description: 'Volunteers fix bicycles every Sunday',
           },
         ])}
+        categories={CATEGORIES}
+        tags={TAGS}
         features={[]}
         webId={1}
         webName="Bristol"
@@ -208,6 +208,8 @@ describe('the web page category filter', () => {
     renderPage(
       <Web
         data={webData(LISTINGS)}
+        categories={CATEGORIES}
+        tags={TAGS}
         features={[]}
         webId={1}
         webName="Bristol"

--- a/app/[subdomain]/page.tsx
+++ b/app/[subdomain]/page.tsx
@@ -83,9 +83,6 @@ type DataType = {
   // gzip+base64 compressed network visualization data ({ nodes, edges }).
   // Kept compressed across the wire and decompressed on the client in Web.tsx.
   data: string
-  // For the filter dropdowns. Fetching these from /api/categories and
-  // /api/tags after hydration cost every visitor to an otherwise fully static
-  // page two serverless invocations and four queries.
   categories: Array<{ label: string; color: string; icon: string }>
   tags: Array<{ id: number; label: string }>
   webData: {

--- a/app/[subdomain]/page.tsx
+++ b/app/[subdomain]/page.tsx
@@ -25,11 +25,13 @@ export default async function WebPage(props) {
     return notFound()
   }
 
-  const { data, webData } = rawData
+  const { data, webData, categories, tags } = rawData
 
   return (
     <Web
       data={data}
+      categories={categories}
+      tags={tags}
       events={events}
       features={webData.features}
       webId={webData.id}
@@ -81,6 +83,11 @@ type DataType = {
   // gzip+base64 compressed network visualization data ({ nodes, edges }).
   // Kept compressed across the wire and decompressed on the client in Web.tsx.
   data: string
+  // For the filter dropdowns. Fetching these from /api/categories and
+  // /api/tags after hydration cost every visitor to an otherwise fully static
+  // page two serverless invocations and four queries.
+  categories: Array<{ label: string; color: string; icon: string }>
+  tags: Array<{ id: number; label: string }>
   webData: {
     id: number
     title: string
@@ -391,10 +398,33 @@ async function getData({ webSlug }): Promise<DataType> {
     })
   }
 
+  // Label-sorted, as the client hook sorted them: the category's index here is
+  // what picks a listing's placeholder pattern.
+  const publicCategories = categories
+    .map(({ label, color, icon }) => ({ label, color, icon }))
+    .sort((a, b) => {
+      if (a.label < b.label) return -1
+      if (a.label > b.label) return 1
+      return 0
+    })
+
+  // Only tags carried by a visible listing are worth offering as a filter.
+  const tagsById = new Map<number, { id: number; label: string }>()
+  for (const category of categories) {
+    for (const placement of category.listings) {
+      for (const tag of placement.tags) {
+        tagsById.set(tag.id, { id: tag.id, label: tag.label })
+      }
+    }
+  }
+  const publicTags = [...tagsById.values()].sort((a, b) => a.id - b.id)
+
   return {
     // Compress only the network visualization data — it's the large payload.
     // webData is small and is consumed directly for props/metadata.
     data: compressJson(transformedData),
+    categories: publicCategories,
+    tags: publicTags,
     // @ts-ignore
     webData,
   }

--- a/app/api/analytics/track/__tests__/route.integration.test.ts
+++ b/app/api/analytics/track/__tests__/route.integration.test.ts
@@ -1,0 +1,138 @@
+import { createListing, createWeb } from '@/test/factories'
+import { request } from '@/test/http'
+import { describe, expect, it } from 'vitest'
+import prisma from '@prisma-rw'
+import { POST as track } from '../route.ts'
+
+/** A real browser user agent — `isBot` drops anything that looks like a crawler. */
+const BROWSER =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36'
+
+const post = (body: unknown, userAgent = BROWSER) =>
+  track(
+    request('/api/analytics/track', {
+      method: 'POST',
+      body,
+      headers: { 'user-agent': userAgent },
+    }),
+  )
+
+const webCounts = () =>
+  prisma.webAnalyticsDaily.findMany({
+    select: { eventType: true, count: true },
+  })
+
+describe('POST /api/analytics/track', () => {
+  it('records a whole session of events in one request', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+    const listing = await createListing(web.id)
+
+    const response = await post({
+      events: [
+        { webId: web.id, eventType: 'view', count: 3 },
+        {
+          listingId: listing.id,
+          webId: web.id,
+          eventType: 'view',
+          count: 2,
+        },
+        {
+          listingId: listing.id,
+          webId: web.id,
+          eventType: 'action_contact',
+          count: 1,
+        },
+      ],
+    })
+
+    expect(response.status).toBe(200)
+    expect(await webCounts()).toEqual([{ eventType: 'view', count: 3 }])
+    expect(
+      await prisma.listingAnalyticsDaily.findMany({
+        select: { eventType: true, count: true },
+        orderBy: { eventType: 'asc' },
+      }),
+    ).toEqual([
+      { eventType: 'action_contact', count: 1 },
+      { eventType: 'view', count: 2 },
+    ])
+  })
+
+  it('adds to the day already being counted rather than starting again', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    await post({ events: [{ webId: web.id, eventType: 'view', count: 4 }] })
+    await post({ events: [{ webId: web.id, eventType: 'view', count: 6 }] })
+
+    expect(await webCounts()).toEqual([{ eventType: 'view', count: 10 }])
+  })
+
+  it('still accepts a single unbatched event from an older client', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await post({ webId: web.id, eventType: 'view' })
+
+    expect(response.status).toBe(200)
+    expect(await webCounts()).toEqual([{ eventType: 'view', count: 1 }])
+  })
+
+  it('ignores a crawler', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    await post(
+      { events: [{ webId: web.id, eventType: 'view', count: 1 }] },
+      'Googlebot/2.1',
+    )
+
+    expect(await webCounts()).toEqual([])
+  })
+
+  it('drops events it does not recognise, and keeps the rest', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    await post({
+      events: [
+        { webId: web.id, eventType: 'drop_database', count: 1 },
+        { webId: web.id, eventType: 'view', count: 1 },
+      ],
+    })
+
+    expect(await webCounts()).toEqual([{ eventType: 'view', count: 1 }])
+  })
+
+  it('rejects a batch with nothing valid in it', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await post({
+      events: [{ webId: web.id, eventType: 'drop_database', count: 1 }],
+    })
+
+    expect(response.status).toBe(400)
+    expect(await webCounts()).toEqual([])
+  })
+
+  it('refuses a batch large enough to be an attempt to hammer the database', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    const response = await post({
+      events: Array.from({ length: 51 }, () => ({
+        webId: web.id,
+        eventType: 'view',
+        count: 1,
+      })),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await webCounts()).toEqual([])
+  })
+
+  it('caps how far a single event can advance a counter', async () => {
+    const web = await createWeb({ slug: 'bristol' })
+
+    await post({
+      events: [{ webId: web.id, eventType: 'view', count: 1_000_000 }],
+    })
+
+    expect(await webCounts()).toEqual([{ eventType: 'view', count: 100 }])
+  })
+})

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -1,10 +1,7 @@
 import type { NextRequest } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
-import {
-  isBot,
-  recordListingEvent,
-  recordWebEvent,
-} from '@db/analyticsRepository'
+import type { AnalyticsEventInput } from '@db/analyticsRepository'
+import { isBot, recordEvents } from '@db/analyticsRepository'
 
 const VALID_EVENT_TYPES = [
   'view',
@@ -16,6 +13,30 @@ const VALID_EVENT_TYPES = [
   'action_corporate_volunteering',
 ]
 
+/** One request carries a whole session, so cap what a single caller can write. */
+const MAX_EVENTS_PER_REQUEST = 50
+const MAX_COUNT_PER_EVENT = 100
+
+function parseEvent(raw: any): AnalyticsEventInput | null {
+  if (!raw || typeof raw !== 'object') return null
+
+  const { listingId, webId, eventType } = raw
+  if (!eventType || !VALID_EVENT_TYPES.includes(eventType)) return null
+  if (!Number.isInteger(webId)) return null
+  if (listingId !== undefined && !Number.isInteger(listingId)) return null
+
+  // A missing or malformed count means one occurrence.
+  const rawCount = Number(raw.count ?? 1)
+  const count =
+    Number.isFinite(rawCount) && rawCount > 0
+      ? Math.min(Math.floor(rawCount), MAX_COUNT_PER_EVENT)
+      : 1
+
+  return listingId
+    ? { listingId, webId, eventType, count }
+    : { webId, eventType, count }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const userAgent = request.headers.get('user-agent')
@@ -24,40 +45,23 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { listingId, webId, eventType } = body
 
-    if (!eventType || !VALID_EVENT_TYPES.includes(eventType)) {
-      return Response.json({ error: 'Invalid event type' }, { status: 400 })
+    // The batched shape, or the single event a cached older bundle still posts.
+    const rawEvents = Array.isArray(body?.events) ? body.events : [body]
+
+    if (rawEvents.length > MAX_EVENTS_PER_REQUEST) {
+      return Response.json({ error: 'Too many events' }, { status: 400 })
     }
 
-    if (!listingId && !webId) {
-      return Response.json(
-        { error: 'Either listingId or webId is required' },
-        { status: 400 },
-      )
+    const events = rawEvents
+      .map(parseEvent)
+      .filter((event): event is AnalyticsEventInput => event !== null)
+
+    if (events.length === 0) {
+      return Response.json({ error: 'No valid events' }, { status: 400 })
     }
 
-    if (listingId && typeof listingId !== 'number') {
-      return Response.json({ error: 'Invalid listingId' }, { status: 400 })
-    }
-
-    if (webId && typeof webId !== 'number') {
-      return Response.json({ error: 'Invalid webId' }, { status: 400 })
-    }
-
-    if (listingId) {
-      if (!webId) {
-        return Response.json(
-          { error: 'webId is required when tracking a listing event' },
-          { status: 400 },
-        )
-      }
-      await recordListingEvent(listingId, webId, eventType)
-    }
-
-    if (webId && !listingId) {
-      await recordWebEvent(webId, eventType)
-    }
+    await recordEvents(events)
 
     return Response.json({ ok: true })
   } catch (e) {

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -4,7 +4,6 @@ import { requireWebEditor } from '@/lib/api-authorization'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 
-/** The web a category belongs to is what the caller needs rights over. */
 async function findCategoryWebId(categoryId: number) {
   if (!Number.isInteger(categoryId)) {
     return null
@@ -33,8 +32,6 @@ export async function PATCH(
   if (denied) return denied
 
   try {
-    // Enumerated, not spread: `data: body` would let the caller move the
-    // category to a web they have no rights over.
     const category = await prisma.category.update({
       where: {
         id: categoryId,
@@ -94,8 +91,6 @@ export async function DELETE(
       },
     })
 
-    // The web page's category filter is built server-side, so a deleted
-    // category has to be rebuilt out of it.
     revalidatePath(`/${category.web.slug}`)
 
     return Response.json({ data: category })

--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -85,7 +85,18 @@ export async function DELETE(
       where: {
         id: categoryId,
       },
+      include: {
+        web: {
+          select: {
+            slug: true,
+          },
+        },
+      },
     })
+
+    // The web page's category filter is built server-side, so a deleted
+    // category has to be rebuilt out of it.
+    revalidatePath(`/${category.web.slug}`)
 
     return Response.json({ data: category })
   } catch (e) {

--- a/app/api/tags/[id]/route.ts
+++ b/app/api/tags/[id]/route.ts
@@ -22,8 +22,6 @@ export async function PATCH(
   if (denied) return denied
 
   try {
-    // Enumerated, not spread: `data: body` would let the caller move the tag
-    // to a web they have no rights over.
     const tag = await prisma.tag.update({
       where: {
         id: tagId,
@@ -81,8 +79,6 @@ export async function DELETE(
       },
     })
 
-    // The web page's tag filter is built server-side, so a deleted tag has to
-    // be rebuilt out of it.
     revalidatePath(`/${tag.web.slug}`)
 
     return Response.json({ data: tag })

--- a/app/api/tags/[id]/route.ts
+++ b/app/api/tags/[id]/route.ts
@@ -72,7 +72,18 @@ export async function DELETE(
       where: {
         id: tagId,
       },
+      include: {
+        web: {
+          select: {
+            slug: true,
+          },
+        },
+      },
     })
+
+    // The web page's tag filter is built server-side, so a deleted tag has to
+    // be rebuilt out of it.
+    revalidatePath(`/${tag.web.slug}`)
 
     return Response.json({ data: tag })
   } catch (e) {

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,19 +1,22 @@
 'use client'
 
-import { useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import {
   isServer,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
 
+// Dynamic so neither `posthog-js` nor its React bindings reach the entry chunk.
 const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
   ssr: false,
 })
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then((m) => m.ReactQueryDevtools),
+  { ssr: false },
+)
 
 function makeQueryClient() {
   return new QueryClient({
@@ -50,32 +53,13 @@ export default function Providers({ children }) {
   //       render if it suspends and there is no boundary
   const queryClient = getQueryClient()
 
-  useEffect(() => {
-    if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-        api_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
-        ui_host: 'https://eu.posthog.com',
-        debug: false,
-        capture_pageview: false,
-        capture_pageleave: true,
-        persistence: 'localStorage',
-        capture_exceptions: true,
-        capture_performance: true,
-        session_recording: {
-          maskAllInputs: false,
-        },
-      })
-    }
-  }, [])
-
   return (
-    <PostHogProvider client={posthog}>
-      <QueryClientProvider client={queryClient}>
-        <PostHogPageView />
-        {children}
+    <QueryClientProvider client={queryClient}>
+      <PostHogPageView />
+      {children}
+      {process.env.NODE_ENV === 'development' && (
         <ReactQueryDevtools buttonPosition="bottom-right" />
-      </QueryClientProvider>
-    </PostHogProvider>
+      )}
+    </QueryClientProvider>
   )
 }

--- a/components/listing/Listing.tsx
+++ b/components/listing/Listing.tsx
@@ -24,7 +24,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@components/ui/tooltip'
-import useCategoriesPublic from '@hooks/categories/useCategoriesPublic'
 
 const ListingMap = dynamic(() => import('@components/listing-map'), {
   ssr: false,
@@ -38,7 +37,8 @@ const ListingMap = dynamic(() => import('@components/listing-map'), {
   ),
 })
 
-function Listing({ listing }) {
+/** `categories` is every category in this listing's web, label-sorted. */
+function Listing({ listing, categories }) {
   useEffect(() => {
     if (listing.web?.id) {
       trackListingEvent(listing.id, listing.web.id, 'view')
@@ -47,7 +47,6 @@ function Listing({ listing }) {
 
   const websiteSanitized = sanitizeLink(listing.website)
 
-  const { categories } = useCategoriesPublic({ webSlug: listing.web?.slug })
   const categoriesIndexesObj = {}
   categories?.map((c, i) => (categoriesIndexesObj[c.label] = i))
   const categoriesIndexes = categoriesIndexesObj

--- a/components/listings-map/ListingsMap.tsx
+++ b/components/listings-map/ListingsMap.tsx
@@ -23,7 +23,6 @@ import {
 import Item from '@components/main-list/item'
 import { Button } from '@components/ui/button'
 import { Spinner } from '@components/ui/spinner'
-import useCategoriesPublic from '@hooks/categories/useCategoriesPublic'
 
 interface RelatedWeb {
   slug: string
@@ -36,8 +35,9 @@ interface RelatedWeb {
 
 interface MapProps {
   items?: any[]
-  webSlug: string
   relatedWebs?: RelatedWeb[]
+  /** Every category in this web, label-sorted. */
+  categories?: { label: string }[]
 }
 
 function MarkerClusterGroup({ items }: { items: any[] }) {
@@ -136,13 +136,12 @@ function FitBoundsToMarkers({ markers }: { markers: [number, number][] }) {
   return null
 }
 
-function ListingsMap({ items = [], webSlug, relatedWebs = [] }: MapProps) {
+function ListingsMap({ items = [], relatedWebs = [], categories }: MapProps) {
   const [isLoading, setIsLoading] = useState(true)
   const [isFullScreen, setIsFullScreen] = useState(false)
   const [isUnmappedPanelOpen, setIsUnmappedPanelOpen] = useState(false)
   const mapContainerRef = useRef<HTMLDivElement>(null)
 
-  const { categories } = useCategoriesPublic({ webSlug })
   const categoriesIndexes = useMemo(() => {
     const obj: Record<string, number> = {}
     categories?.map((c, i) => (obj[c.label] = i))

--- a/components/main-list/MainList.tsx
+++ b/components/main-list/MainList.tsx
@@ -5,16 +5,16 @@ import NextLink from 'next/link'
 import { REMOTE_URL } from '@helpers/config'
 import Footer from '@components/footer'
 import { Button } from '@components/ui/button'
-import useCategoriesPublic from '@hooks/categories/useCategoriesPublic'
 import Item from './item'
 
 interface MainListProps {
   filteredItems: any[]
   webSlug: string
+  /** Every category in this web, label-sorted. */
+  categories?: { label: string }[]
 }
 
-const MainList = ({ filteredItems, webSlug }: MainListProps) => {
-  const { categories } = useCategoriesPublic({ webSlug })
+const MainList = ({ filteredItems, webSlug, categories }: MainListProps) => {
   const categoriesIndexesObj = {}
   categories?.map((c, i) => (categoriesIndexesObj[c.label] = i))
   const categoriesIndexes = categoriesIndexesObj

--- a/db/analyticsRepository.ts
+++ b/db/analyticsRepository.ts
@@ -38,6 +38,61 @@ export async function recordListingEvent(
   })
 }
 
+export type AnalyticsEventInput = {
+  listingId?: number
+  webId: number
+  eventType: string
+  count: number
+}
+
+/** Applies a whole session's events in one transaction rather than one upsert per view. */
+export async function recordEvents(events: AnalyticsEventInput[]) {
+  if (events.length === 0) return
+
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  const writes = events.map((event) =>
+    event.listingId
+      ? prisma.listingAnalyticsDaily.upsert({
+          where: {
+            listing_web_date_event: {
+              listingId: event.listingId,
+              webId: event.webId,
+              date: today,
+              eventType: event.eventType,
+            },
+          },
+          update: { count: { increment: event.count } },
+          create: {
+            listingId: event.listingId,
+            webId: event.webId,
+            date: today,
+            eventType: event.eventType,
+            count: event.count,
+          },
+        })
+      : prisma.webAnalyticsDaily.upsert({
+          where: {
+            web_date_event: {
+              webId: event.webId,
+              date: today,
+              eventType: event.eventType,
+            },
+          },
+          update: { count: { increment: event.count } },
+          create: {
+            webId: event.webId,
+            date: today,
+            eventType: event.eventType,
+            count: event.count,
+          },
+        }),
+  )
+
+  await prisma.$transaction(writes)
+}
+
 export async function recordWebEvent(webId: number, eventType: string) {
   const today = new Date()
   today.setUTCHours(0, 0, 0, 0)

--- a/helpers/analytics.ts
+++ b/helpers/analytics.ts
@@ -1,19 +1,93 @@
+/**
+ * Client-side analytics queue.
+ *
+ * Each event used to be its own `POST /api/analytics/track` the moment it
+ * happened — a serverless invocation and a Postgres upsert per page view.
+ * Events are now counted in memory and sent once, when the page goes away, so
+ * a whole session is normally a single request.
+ */
+
+const ENDPOINT = '/api/analytics/track'
+
+/** Flush early rather than let a very long session build an unbounded queue. */
+const MAX_QUEUED_EVENTS = 25
+
+type QueuedEvent = {
+  listingId?: number
+  webId: number
+  eventType: string
+  count: number
+}
+
+const queue = new Map<string, QueuedEvent>()
+let listenersAttached = false
+
+function flush() {
+  if (queue.size === 0) return
+
+  const events = [...queue.values()]
+  queue.clear()
+
+  const body = JSON.stringify({ events })
+
+  // `sendBeacon` survives the page unloading, which `fetch` only sometimes
+  // does. It returns false if the payload is refused, hence the fallback.
+  try {
+    const blob = new Blob([body], { type: 'application/json' })
+    if (navigator.sendBeacon?.(ENDPOINT, blob)) return
+  } catch {
+    // Fall through to fetch.
+  }
+
+  fetch(ENDPOINT, {
+    method: 'POST',
+    body,
+    keepalive: true,
+    headers: { 'Content-Type': 'application/json' },
+  }).catch(() => {})
+}
+
+function attachListeners() {
+  if (listenersAttached || typeof document === 'undefined') return
+  listenersAttached = true
+
+  // `hidden` covers backgrounding on mobile, where `pagehide` may never fire.
+  // Flushing twice is harmless — the queue empties on the first.
+  window.addEventListener('pagehide', flush)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flush()
+  })
+}
+
+function enqueue(event: Omit<QueuedEvent, 'count'>) {
+  if (typeof window === 'undefined') return
+
+  attachListeners()
+
+  const key = `${event.listingId ?? ''}:${event.webId}:${event.eventType}`
+  const existing = queue.get(key)
+  if (existing) {
+    existing.count += 1
+  } else {
+    queue.set(key, { ...event, count: 1 })
+  }
+
+  if (queue.size >= MAX_QUEUED_EVENTS) flush()
+}
+
 export function trackListingEvent(
   listingId: number,
   webId: number,
   eventType: string,
 ) {
-  fetch('/api/analytics/track', {
-    method: 'POST',
-    body: JSON.stringify({ listingId, webId, eventType }),
-    keepalive: true,
-  }).catch(() => {})
+  enqueue({ listingId, webId, eventType })
 }
 
 export function trackWebEvent(webId: number, eventType: string) {
-  fetch('/api/analytics/track', {
-    method: 'POST',
-    body: JSON.stringify({ webId, eventType }),
-    keepalive: true,
-  }).catch(() => {})
+  enqueue({ webId, eventType })
+}
+
+/** For anywhere that needs the queue drained right now. */
+export function flushAnalytics() {
+  flush()
 }

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -7,6 +7,11 @@ import {
   BROWSER_EXTENSION_URLS,
 } from '@helpers/sentry'
 
+// Fraction of requests traced. Errors are captured whatever this is.
+const TRACES_SAMPLE_RATE = Number(
+  process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ?? 0.1,
+)
+
 Sentry.init({
   dsn: 'https://a205584b48c84a7fbfcd3632479d33f7@o4505069644611584.ingest.sentry.io/4505069646643200',
   enabled: process.env.NODE_ENV === 'production',
@@ -15,21 +20,36 @@ Sentry.init({
   ignoreErrors: BROWSER_EXTENSION_ERRORS,
   denyUrls: BROWSER_EXTENSION_URLS,
 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: TRACES_SAMPLE_RATE,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  replaysOnErrorSampleRate: 1.0,
-  replaysSessionSampleRate: 0,
-
-  integrations: [
-    Sentry.feedbackIntegration({
-      colorScheme: 'system',
-    }),
-    Sentry.replayIntegration(),
-  ],
+  // Session Replay is deliberately absent: it bundles rrweb into the entry
+  // chunk on every page, and PostHog session recording already records this.
+  integrations: [],
 })
+
+// ~21 KiB gzipped, and nobody clicks it in the first seconds of a page.
+function loadFeedbackWidget() {
+  void Sentry.lazyLoadIntegration('feedbackIntegration')
+    .then((feedbackIntegration) => {
+      Sentry.getClient()?.addIntegration(
+        feedbackIntegration({ colorScheme: 'system' }),
+      )
+      return feedbackIntegration
+    })
+    .catch(() => {
+      // A blocked or failed CDN fetch should cost the page nothing.
+    })
+}
+
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(loadFeedbackWidget, { timeout: 5000 })
+  } else {
+    window.setTimeout(loadFeedbackWidget, 3000)
+  }
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -11,6 +11,9 @@ import * as Sentry from '@sentry/nextjs'
 const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build'
 const isProduction = process.env.NODE_ENV === 'production' && !isBuildPhase
 
+// Fraction of requests traced. Errors are captured whatever this is.
+const TRACES_SAMPLE_RATE = Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.1)
+
 const posthogApiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
 const posthogHost =
   process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com'
@@ -65,7 +68,7 @@ export function register() {
     Sentry.init({
       dsn: 'https://a205584b48c84a7fbfcd3632479d33f7@o4505069644611584.ingest.sentry.io/4505069646643200',
       enabled: isProduction,
-      tracesSampleRate: 1,
+      tracesSampleRate: TRACES_SAMPLE_RATE,
       debug: false,
     })
 
@@ -76,7 +79,7 @@ export function register() {
     Sentry.init({
       dsn: 'https://a205584b48c84a7fbfcd3632479d33f7@o4505069644611584.ingest.sentry.io/4505069646643200',
       enabled: isProduction,
-      tracesSampleRate: 1,
+      tracesSampleRate: TRACES_SAMPLE_RATE,
       debug: false,
     })
   }

--- a/next.config.js
+++ b/next.config.js
@@ -101,6 +101,14 @@ export default withSentryConfig(
     authToken: process.env.SENTRY_AUTH_TOKEN,
     // Suppresses source map uploading logs during build
     silent: true,
+    // Session Replay isn't initialised on the client, so its recording
+    // machinery doesn't need to ship.
+    bundleSizeOptimizations: {
+      excludeDebugStatements: true,
+      excludeReplayShadowDom: true,
+      excludeReplayIframe: true,
+      excludeReplayWorker: true,
+    },
     // Upload a larger set of source maps for prettier stack traces (increases build time)
     widenClientFileUpload: false,
     // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)


### PR DESCRIPTION
Tier 1 of a performance audit. Everything here is measured against the production build output, not estimated.

| | Before | After |
|---|---|---|
| Root bundle (every page) | 287 KB gz | **221 KB gz** |
| First-load JS, public web page | 697 KB gz | **544 KB gz** |
| Network requests per visitor on a static page | 3 | **0–1** |
| DB queries per visitor on a static page | 5 | **0–4 per session** |

## Observability was 44% of the JS on every public page

Sentry was 226 KB gz and PostHog 82 KB gz, both in the entry chunk. The app shipped two session-replay engines.

- **Sentry Session Replay is gone.** It bundled rrweb into the entry chunk on every page, and PostHog session recording — which we already pay for, and which lazy-loads its own recorder — records the same thing. `bundleSizeOptimizations` tree-shakes what was left behind. `rrweb` no longer appears in the entry chunk at all.
- **The Sentry feedback widget is lazy-loaded on idle** via `lazyLoadIntegration`. The button still appears; it just isn't 21 KB gz on the critical path.
- **`posthog-js` is imported on idle** from `PostHogPageView` rather than statically from the root providers. The ~13 modules that import the singleton directly are untouched. Same treatment for the react-query devtools.
- **`tracesSampleRate` 1.0 → 0.1** on client, node and edge, each overridable by env var. Error capture is unaffected.

## Static pages no longer phone home three times per visitor

`/[subdomain]` and the listing pages are `revalidate = false` — pure CDN — but every visitor still triggered `GET /api/categories`, `GET /api/tags` and `POST /api/analytics/track`.

- `getData()` derives the filter lists from the query it already runs and passes them as props through `Web` → `MainList`/`ListingsMap`. `getListing` pulls `web.categories` along on its existing join, so no extra round trip. `useCategoriesPublic`/`useTagsPublic` are gone from every public component; the two admin form pages still use them, correctly.
- Analytics is now an in-memory queue keyed by event, flushed once via `sendBeacon` on `pagehide`/`visibilitychange`, with repeats collapsed into a `count`. A visitor reading six listings sends one request with a handful of rows instead of six requests and six upserts. The route applies a batch in a single `$transaction` and still accepts the single unbatched event a browser running a cached older bundle will post.

## Two things this made necessary

- `DELETE` on categories and tags never called `revalidatePath`. Harmless while the filters were fetched live; now that they're baked into the page it would leave a deleted category in the dropdown until the next deploy.
- `ListingsMap`'s `webSlug` prop was only ever used by the hook, so it and its call site are removed.

## Behaviour change worth a look

The tag filter is now derived from tags on **visible** listings, where before it was any tag with a non-zero placement count. A tag attached only to a pending or inactive listing used to appear in the dropdown and match nothing; now it doesn't. I think that's better, but it is a change.

## Steps to test

1. Load a web page and check the network tab: no `/api/categories` or `/api/tags`, and no `/api/analytics/track` until you navigate away or background the tab.
2. Filter by category and tag, search, switch between web/list/map — all should behave as before.
3. Rename or delete a category in admin, then reload the web page: the filter should reflect it.
4. Confirm the Sentry feedback button still appears (a second or two later than before).
5. Check PostHog still receives pageviews and session recordings.

`npm run quality:dry` and `npm run test:integration` are clean — 240 + 137 passing. Seven new integration tests cover the analytics route (batching, incrementing an existing day, the old shape, bots, invalid types, both caps); I checked they go red when the batch path is removed, and that the filtering tests go red without the new props.

Next largest item on the page is 64 KB gz of Zod pulled in by the footer newsletter form — a `next/dynamic` there takes the web page under 500 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)