### PR TITLE
perf: mount one TooltipProvider at the root

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -56,12 +56,6 @@ export default function Providers({ children }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      {/*
-        One provider for the whole app, as Radix intends. Mounting one per
-        tooltip meant a list of 500 listings mounted 1000 of them, and each was
-        its own scope — so moving between two tooltips always waited out the
-        open delay instead of skipping it.
-      */}
       <TooltipProvider>
         <PostHogPageView />
         {children}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
+import { TooltipProvider } from '@components/ui/tooltip'
 
 // Dynamic so neither `posthog-js` nor its React bindings reach the entry chunk.
 const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
@@ -55,11 +56,19 @@ export default function Providers({ children }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <PostHogPageView />
-      {children}
-      {process.env.NODE_ENV === 'development' && (
-        <ReactQueryDevtools buttonPosition="bottom-right" />
-      )}
+      {/*
+        One provider for the whole app, as Radix intends. Mounting one per
+        tooltip meant a list of 500 listings mounted 1000 of them, and each was
+        its own scope — so moving between two tooltips always waited out the
+        open delay instead of skipping it.
+      */}
+      <TooltipProvider>
+        <PostHogPageView />
+        {children}
+        {process.env.NODE_ENV === 'development' && (
+          <ReactQueryDevtools buttonPosition="bottom-right" />
+        )}
+      </TooltipProvider>
     </QueryClientProvider>
   )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import {
-  isServer,
+  environmentManager,
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query'
@@ -34,7 +34,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined
 
 function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient()
   } else {

--- a/components/admin/categories/header/category-dialog/category-form/CategoryForm.tsx
+++ b/components/admin/categories/header/category-dialog/category-form/CategoryForm.tsx
@@ -12,12 +12,7 @@ import {
   FormMessage,
 } from '@components/ui/form'
 import { Input } from '@components/ui/input'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 import IconSelector from './IconSelector'
 
 const randomHexColorCode = () => {
@@ -150,27 +145,25 @@ const CategoryForm = ({
 
         <DialogFooter className="flex flex-col gap-2">
           {category && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="destructive"
-                    className="opacity-85"
-                    onClick={onDelete}
-                    disabled={category?._count?.listings > 0}
-                    type="button"
-                  >
-                    Remove
-                  </Button>
-                </TooltipTrigger>
-                {category?._count?.listings > 0 && (
-                  <TooltipContent className="z-200">
-                    To delete this category, first ensure there are no listings
-                    associated with it
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="destructive"
+                  className="opacity-85"
+                  onClick={onDelete}
+                  disabled={category?._count?.listings > 0}
+                  type="button"
+                >
+                  Remove
+                </Button>
+              </TooltipTrigger>
+              {category?._count?.listings > 0 && (
+                <TooltipContent className="z-200">
+                  To delete this category, first ensure there are no listings
+                  associated with it
+                </TooltipContent>
+              )}
+            </Tooltip>
           )}
 
           <Button

--- a/components/admin/tags/header/tag-dialog/tag-form/TagForm.tsx
+++ b/components/admin/tags/header/tag-dialog/tag-form/TagForm.tsx
@@ -12,12 +12,7 @@ import {
   FormMessage,
 } from '@components/ui/form'
 import { Input } from '@components/ui/input'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 
 const formSchema = z.object({
   label: z.string().min(1, 'Label is required'),
@@ -67,29 +62,27 @@ const TagForm = ({
 
         <DialogFooter className="flex flex-col gap-2">
           {tag && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    disabled={tag?.listings?.length > 0}
-                    className="opacity-85"
-                    onClick={onDelete}
-                  >
-                    Remove
-                  </Button>
-                </TooltipTrigger>
-                {tag?.listings?.length > 0 && (
-                  <TooltipContent>
-                    <p>
-                      To delete this tag, first ensure there are no listings
-                      associated with it
-                    </p>
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  disabled={tag?.listings?.length > 0}
+                  className="opacity-85"
+                  onClick={onDelete}
+                >
+                  Remove
+                </Button>
+              </TooltipTrigger>
+              {tag?.listings?.length > 0 && (
+                <TooltipContent>
+                  <p>
+                    To delete this tag, first ensure there are no listings
+                    associated with it
+                  </p>
+                </TooltipContent>
+              )}
+            </Tooltip>
           )}
           <Button type="submit" disabled={!form.formState.isValid}>
             {tag ? 'Update' : 'Create'}

--- a/components/contact-dialog/GetInTouchButton.tsx
+++ b/components/contact-dialog/GetInTouchButton.tsx
@@ -4,12 +4,7 @@ import { useState } from 'react'
 import { MdOutlineQuestionMark } from 'react-icons/md'
 import dynamic from 'next/dynamic'
 import { Button } from '@components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 import useIsMobile from '@hooks/application/useIsMobile'
 
 const ContactDialog = dynamic(() => import('./ContactDialog'), { ssr: false })
@@ -30,40 +25,38 @@ const GetInTouchButton = ({
 
   return (
     <>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            {isMobile ? (
-              <Button
-                variant="outline"
-                size="icon"
-                className="text-xl"
-                onPointerEnter={warmContactDialog}
-                onFocus={warmContactDialog}
-                onClick={() => setIsContactDialogOpen(true)}
-              >
-                <MdOutlineQuestionMark className="h-5 w-5" />
-                <span className="sr-only">Help & feedback</span>
-              </Button>
-            ) : (
-              <Button
-                variant="outline"
-                onPointerEnter={warmContactDialog}
-                onFocus={warmContactDialog}
-                onClick={() => setIsContactDialogOpen(true)}
-              >
-                Help & feedback
-              </Button>
-            )}
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>
-              Questions or feedback about the Resilience Web platform? Contact
-              the team here
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {isMobile ? (
+            <Button
+              variant="outline"
+              size="icon"
+              className="text-xl"
+              onPointerEnter={warmContactDialog}
+              onFocus={warmContactDialog}
+              onClick={() => setIsContactDialogOpen(true)}
+            >
+              <MdOutlineQuestionMark className="h-5 w-5" />
+              <span className="sr-only">Help & feedback</span>
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onPointerEnter={warmContactDialog}
+              onFocus={warmContactDialog}
+              onClick={() => setIsContactDialogOpen(true)}
+            >
+              Help & feedback
+            </Button>
+          )}
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Questions or feedback about the Resilience Web platform? Contact the
+            team here
+          </p>
+        </TooltipContent>
+      </Tooltip>
 
       {isContactDialogOpen && (
         <ContactDialog

--- a/components/listing/Listing.tsx
+++ b/components/listing/Listing.tsx
@@ -18,12 +18,7 @@ import RichText from '@components/rich-text'
 import ShareButton from '@components/share-button'
 import { Badge } from '@components/ui/badge'
 import { Button } from '@components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 
 const ListingMap = dynamic(() => import('@components/listing-map'), {
   ssr: false,
@@ -174,22 +169,20 @@ function Listing({ listing, categories }) {
             )}
 
             {listing.seekingVolunteers && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex cursor-help items-center gap-1 rounded-full border border-transparent bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 md:gap-1.5 md:px-3">
-                      <HiUserGroup className="h-3 w-3 md:h-3.5 md:w-3.5" />
-                      Seeking volunteers
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-50">
-                    <p className="text-center text-sm">
-                      This group is seeking volunteers or members. Get in touch
-                      with them if you'd like to help.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex cursor-help items-center gap-1 rounded-full border border-transparent bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 md:gap-1.5 md:px-3">
+                    <HiUserGroup className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                    Seeking volunteers
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-50">
+                  <p className="text-center text-sm">
+                    This group is seeking volunteers or members. Get in touch
+                    with them if you'd like to help.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
             )}
 
             {/* Mobile only: Social icons inline with badges */}

--- a/components/main-list/item/Item.tsx
+++ b/components/main-list/item/Item.tsx
@@ -11,12 +11,7 @@ import { isBranchDeploy } from '@helpers/config'
 import CategoryTag from '@components/category-tag'
 import ListingImage from '@components/listing-image'
 import { Badge } from '@components/ui/badge'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 import ImagePlaceholder from './image-placeholder'
 
 type Props = {
@@ -60,16 +55,14 @@ const Item = ({ categoriesIndexes, dataItem, simplified = false }: Props) => {
       ref={ref}
     >
       {isFeatured && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <FaStar className="absolute top-[140px] z-100 h-[26px] w-[26px] text-yellow-200 right-1 bottom-1" />
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Featured listing</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <FaStar className="absolute top-[140px] z-100 h-[26px] w-[26px] text-yellow-200 right-1 bottom-1" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Featured listing</p>
+          </TooltipContent>
+        </Tooltip>
       )}
       {dataItem.new && (
         <Badge variant="secondary" className="absolute top-1 right-1 z-10">
@@ -108,21 +101,19 @@ const Item = ({ categoriesIndexes, dataItem, simplified = false }: Props) => {
         </div>
         {dataItem.seekingVolunteers && !simplified && (
           <div className="flex">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <p className="text-sm text-primary">
-                    Seeking volunteers <HiUserGroup className="inline" />
-                  </p>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>
-                    This group is seeking volunteers or members. Get in touch
-                    with them if you'd like to help.
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <p className="text-sm text-primary">
+                  Seeking volunteers <HiUserGroup className="inline" />
+                </p>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>
+                  This group is seeking volunteers or members. Get in touch with
+                  them if you'd like to help.
+                </p>
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/components/main-list/item/__tests__/Item.test.tsx
+++ b/components/main-list/item/__tests__/Item.test.tsx
@@ -1,0 +1,38 @@
+import { renderPage } from '@/test/render'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Item from '../Item.tsx'
+
+const dataItem: ListingNodeType = {
+  id: 1,
+  title: 'Bike Kitchen',
+  label: 'Bike Kitchen',
+  description: '',
+  slug: 'bike-kitchen',
+  image: '',
+  website: '',
+  seekingVolunteers: true,
+  featured: null,
+  new: false,
+  tags: [],
+  color: '#b0e3c1',
+  category: { label: 'Transportation', color: '#b0e3c1', icon: 'default' },
+}
+
+/**
+ * The tooltip provider lives once at the app root rather than around each
+ * tooltip, so this is what proves an item still gets one.
+ */
+describe('a listing in the list', () => {
+  it('explains the volunteers badge when it is pointed at', async () => {
+    const { user } = renderPage(
+      <Item categoriesIndexes={{ Transportation: 0 }} dataItem={dataItem} />,
+    )
+
+    await user.hover(screen.getByText(/seeking volunteers/i))
+
+    expect(
+      await screen.findByRole('tooltip', { name: /seeking volunteers/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/components/main-list/listing-dialog/ListingDialog.tsx
+++ b/components/main-list/listing-dialog/ListingDialog.tsx
@@ -20,12 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@components/ui/dialog'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@components/ui/tooltip'
 
 interface DialogProps {
   isOpen: boolean
@@ -153,22 +148,20 @@ const ListingDialog = ({
             )}
 
             {item.seekingVolunteers && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex cursor-help items-center gap-1 rounded-full border border-transparent bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 md:gap-1.5 md:px-3">
-                      <HiUserGroup className="h-3 w-3 md:h-3.5 md:w-3.5" />
-                      Seeking volunteers
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" className="max-w-50">
-                    <p className="text-center text-sm">
-                      This group is seeking volunteers or members. Get in touch
-                      with them if you'd like to help.
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex cursor-help items-center gap-1 rounded-full border border-transparent bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-700 md:gap-1.5 md:px-3">
+                    <HiUserGroup className="h-3 w-3 md:h-3.5 md:w-3.5" />
+                    Seeking volunteers
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-50">
+                  <p className="text-center text-sm">
+                    This group is seeking volunteers or members. Get in touch
+                    with them if you'd like to help.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
 

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, type RenderOptions } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
+import { TooltipProvider } from '@components/ui/tooltip'
 import { AppContext } from '@store/AppContext'
 
 /**
@@ -26,6 +27,7 @@ export interface SelectedWeb {
  *    to start the test on a particular URL state
  *  - the selected web, which every admin screen reads to know what it is
  *    looking at; pass `selectedWeb` to put a test inside one
+ *  - the tooltip provider, which the app mounts once at the root
  *
  * Retries are off, otherwise a deliberately-failing request takes three
  * attempts before the component shows its error state.
@@ -54,7 +56,9 @@ export function renderPage(
   const Providers = ({ children }: { children: ReactNode }) => (
     <NuqsTestingAdapter searchParams={searchParams}>
       <QueryClientProvider client={queryClient}>
-        <AppContext value={appContext}>{children}</AppContext>
+        <TooltipProvider>
+          <AppContext value={appContext}>{children}</AppContext>
+        </TooltipProvider>
       </QueryClientProvider>
     </NuqsTestingAdapter>
   )


### PR DESCRIPTION
Radix wants a single `TooltipProvider` for the app. We mounted one per tooltip — seven places, and a listing carries two of them, so a web with 500 listings mounted **1000 providers and 1000 context values** on the list view.

It was also the wrong behaviour. Each provider is its own scope, so `skipDelayDuration` never applied across items: moving the pointer from one listing's tooltip to the next always waited out the open delay again, instead of opening immediately, which is the whole point of the shared scope.

## Why this is safe

- No `TooltipProvider` anywhere passed props.
- `delayDuration` is set per `Tooltip` in [ui/tooltip.tsx:9](components/ui/tooltip.tsx#L9), not on the provider.

So a single tooltip behaves exactly as before; only the cross-tooltip skip changes, and it changes to the intended behaviour.

## The test harness

`renderPage` provides "the things these components need from their surroundings" — so it now provides this one too, mirroring the root layout.

That's not incidental: removing the per-component providers made **24 existing tests fail** with ``Tooltip` must be used within `TooltipProvider``. The component tests render the real components, so they caught it immediately. There's also a new test that hovers a listing's volunteers badge and asserts the tooltip opens, which goes red if the provider is missing from the harness.

## Steps to test

1. Hover the star on a featured listing, and the "Seeking volunteers" text on another — both tooltips should appear as before.
2. Move between two listings' tooltips quickly; the second should now open instantly rather than re-waiting the delay.
3. Check the tooltips in the admin category and tag dialogs, on the listing page, and on the nav's help button.

`npm run quality:dry` is clean — 245 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)