### PR TITLE
perf: dedupe relation edges with a set rather than a scan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,6 +393,14 @@ Key variables (see [.env.example](.env.example)):
   commit, and when, is the user's. The same goes for `git push`, opening a PR,
   and any other outward-facing or hard-to-reverse action.
 
+- **Don't write comments that restate the code.** A comment earns its place by
+  saying something the code cannot: why a constraint exists, what broke without
+  it, which alternative was rejected and why. `// fetch the user` above a line
+  that fetches the user is noise; a clearer name beats a comment explaining an
+  unclear one. Keep the ones you do write to a line or two — the reason, not an
+  essay about it. If a comment could be deleted without losing information,
+  delete it.
+
 ## Important Notes
 
 - Port 4000 for development (not 3000)

--- a/app/[subdomain]/page.tsx
+++ b/app/[subdomain]/page.tsx
@@ -236,6 +236,12 @@ async function getData({ webSlug }): Promise<DataType> {
     edges: [],
   }
 
+  // Relations are symmetric, so every pair is met twice and only the first
+  // direction is kept. Remembering the ones already added makes that a lookup
+  // rather than a scan of every edge built so far, which grew with the square
+  // of the number of related listings in a web.
+  const relationEdgeKeys = new Set<string>()
+
   // Calculate if web is older than 2 months
   const twoMonthsAgo = new Date()
   twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2)
@@ -302,9 +308,17 @@ async function getData({ webSlug }): Promise<DataType> {
         if (relation.placements.length === 0) {
           return
         }
-        const newEdge = {
-          from: `listing-${listingId}`,
-          to: `listing-${relation.id}`,
+        const from = `listing-${listingId}`
+        const to = `listing-${relation.id}`
+
+        if (relationEdgeKeys.has(`${to}|${from}`)) {
+          return
+        }
+        relationEdgeKeys.add(`${from}|${to}`)
+
+        transformedData.edges.push({
+          from,
+          to,
           dashes: true,
           physics: false,
           smooth: {
@@ -312,14 +326,7 @@ async function getData({ webSlug }): Promise<DataType> {
             type: 'continuous',
             roundness: 0,
           },
-        }
-        if (
-          !transformedData.edges.find(
-            (e) => e.from === newEdge.to && e.to === newEdge.from,
-          )
-        ) {
-          transformedData.edges.push(newEdge)
-        }
+        })
       })
 
       transformedData.edges.push({

--- a/app/[subdomain]/page.tsx
+++ b/app/[subdomain]/page.tsx
@@ -236,10 +236,6 @@ async function getData({ webSlug }): Promise<DataType> {
     edges: [],
   }
 
-  // Relations are symmetric, so every pair is met twice and only the first
-  // direction is kept. Remembering the ones already added makes that a lookup
-  // rather than a scan of every edge built so far, which grew with the square
-  // of the number of related listings in a web.
   const relationEdgeKeys = new Set<string>()
 
   // Calculate if web is older than 2 months


### PR DESCRIPTION
Building the network payload deduped relation edges by scanning every edge created so far:

```js
if (!transformedData.edges.find((e) => e.from === newEdge.to && e.to === newEdge.from)) {
  transformedData.edges.push(newEdge)
}
```

Listings connect relations in both directions — [listings/route.ts:225](app/api/listings/route.ts#L225) writes `relations` *and* `relationOf` — so every pair is met twice and this scan ran for each one. That's quadratic in the number of related listings in a web, and it scanned the category-to-listing edges it could never match along the way.

Remembering the pairs already added makes it a lookup.

## Verified against the real build, not reasoned about

The local seed has no listing relations, so a plain before/after payload comparison would have proved nothing about this code path. I inserted a reciprocal pair (`_related` rows `(1,2)` and `(2,1)`, matching what the API writes), rebuilt on both implementations, and decompressed the network payload out of the prerendered RSC:

```
OLD — relation edges: [{"from":"listing-2","to":"listing-1","dashes":true,…}]
NEW — relation edges: [{"from":"listing-2","to":"listing-1","dashes":true,…}]

edges identical to new implementation: True
```

Exactly one dashed edge either way, same direction kept, and the whole edge array byte-identical. The temporary rows were removed afterwards; `_related` is back to 0.

## Steps to test

1. Open a web whose listings have relations and confirm the dashed connection lines look the same.
2. Click a listing in the graph and check its related listings still highlight.

`npm run tsc`, `eslint`, `prettier` and the 244 unit/component tests are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)