### PR TITLE
perf: drop the per-item timer behind image priority

### DIFF
--- a/app/[subdomain]/__tests__/Web.filtering.test.tsx
+++ b/app/[subdomain]/__tests__/Web.filtering.test.tsx
@@ -223,3 +223,33 @@ describe('the web page category filter', () => {
     await expectHidden(['Community Kitchen', 'Carbon Footprint'])
   })
 })
+
+describe('the images in the list', () => {
+  it('asks for the first screenful up front and leaves the rest until they are scrolled to', async () => {
+    const withImages = Array.from({ length: 9 }, (_, i) => ({
+      title: `Listing ${i}`,
+      category: 'Community',
+      image: `https://example.com/${i}.png`,
+    }))
+
+    renderPage(
+      <Web
+        data={webData(withImages)}
+        categories={CATEGORIES}
+        tags={TAGS}
+        features={[]}
+        webId={1}
+        webName="Bristol"
+        webIsPublished
+        webSlug="bristol"
+      />,
+      { searchParams: { view: 'list' } },
+    )
+
+    const images = await screen.findAllByRole('img', { name: /cover image/i })
+    const eager = images.filter((i) => i.getAttribute('loading') === 'eager')
+
+    expect(images).toHaveLength(9)
+    expect(eager).toHaveLength(6)
+  })
+})

--- a/components/main-list/MainList.tsx
+++ b/components/main-list/MainList.tsx
@@ -7,6 +7,9 @@ import Footer from '@components/footer'
 import { Button } from '@components/ui/button'
 import Item from './item'
 
+/** Two rows of the three-column grid — about a desktop viewport. */
+const EAGERLY_LOADED_IMAGES = 6
+
 interface MainListProps {
   filteredItems: any[]
   webSlug: string
@@ -25,11 +28,12 @@ const MainList = ({ filteredItems, webSlug, categories }: MainListProps) => {
         <div className="mt-4 w-full max-w-[1400px]">
           {filteredItems.length > 0 ? (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              {filteredItems.map((item) => (
+              {filteredItems.map((item, index) => (
                 <Item
                   categoriesIndexes={categoriesIndexes}
                   dataItem={item}
                   key={item.id}
+                  priority={index < EAGERLY_LOADED_IMAGES}
                 />
               ))}
             </div>

--- a/components/main-list/item/Item.tsx
+++ b/components/main-list/item/Item.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useEffect, useState, memo } from 'react'
+import { useState, memo } from 'react'
 import { FaStar } from 'react-icons/fa'
 import { HiUserGroup } from 'react-icons/hi'
-import { useInView } from 'react-intersection-observer'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import chroma from 'chroma-js'
@@ -18,20 +17,17 @@ type Props = {
   categoriesIndexes: Record<string, number>
   dataItem: ListingNodeType
   simplified?: boolean
+  /** Loads the cover image eagerly. Only worth it above the fold. */
+  priority?: boolean
 }
 
-const Item = ({ categoriesIndexes, dataItem, simplified = false }: Props) => {
+const Item = ({
+  categoriesIndexes,
+  dataItem,
+  simplified = false,
+  priority = false,
+}: Props) => {
   const { subdomain } = useParams<{ subdomain: string }>()
-  const [isWithinAFewSecondsOfRender, setIsWithinAFewSecondsOfRender] =
-    useState<boolean>(true)
-  const { ref, inView } = useInView()
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setIsWithinAFewSecondsOfRender(false)
-    }, 3000)
-    return () => clearTimeout(timeout)
-  }, [])
 
   const listingHref = isBranchDeploy()
     ? `/${subdomain}/${dataItem.slug}`
@@ -52,7 +48,6 @@ const Item = ({ categoriesIndexes, dataItem, simplified = false }: Props) => {
     <Link
       href={listingHref}
       className="animate-in fade-in slide-in-from-bottom motion-reduce:animate-none relative block h-fit rounded-md bg-white shadow-md transition-all duration-200 ease-out hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-      ref={ref}
     >
       {isFeatured && (
         <Tooltip>
@@ -82,7 +77,7 @@ const Item = ({ categoriesIndexes, dataItem, simplified = false }: Props) => {
           alt={`${dataItem.label} cover image`}
           src={dataItem.image}
           sizes="(max-width: 768px) 90vw, 300px"
-          priority={inView && isWithinAFewSecondsOfRender}
+          priority={priority}
         />
       ) : (
         categoryIndex !== null &&

--- a/test/fixtures/web.ts
+++ b/test/fixtures/web.ts
@@ -9,6 +9,7 @@ import { compressJson } from '@helpers/compression'
 export interface ListingFixture {
   title: string
   category: string
+  image?: string
   description?: string
   tags?: string[]
   seekingVolunteers?: boolean
@@ -33,6 +34,7 @@ export function webData(
   const listingNodes = listings.map((listing, index) => ({
     id: index + 1,
     label: listing.title,
+    image: listing.image ?? '',
     description: listing.description ?? `About ${listing.title}`,
     group: 'listing',
     slug: listing.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),

--- a/test/setup/components.tsx
+++ b/test/setup/components.tsx
@@ -28,8 +28,18 @@ vi.mock('next/image', () => ({
     } = rest
     const resolved =
       typeof src === 'string' ? src : (src as { src?: string })?.src
-    // eslint-disable-next-line @next/next/no-img-element -- this is the stub that replaces next/image
-    return <img src={resolved} alt={alt as string} {...imgProps} />
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- this is the stub that replaces next/image
+      <img
+        src={resolved}
+        alt={alt as string}
+        // What `priority` turns into in the browser, so a test can see whether
+        // an image was asked for up front or left until it scrolls into view.
+        loading={priority ? 'eager' : 'lazy'}
+        fetchPriority={priority ? 'high' : undefined}
+        {...imgProps}
+      />
+    )
   },
 }))
 


### PR DESCRIPTION
Follows #524. This is the other half of the `Item` cleanup.

Every listing in the list set **its own 3-second timeout and its own intersection observer**, purely to decide whether its cover image loaded eagerly:

```tsx
const [isWithinAFewSecondsOfRender, setIsWithinAFewSecondsOfRender] = useState(true)
const { ref, inView } = useInView()
useEffect(() => {
  const timeout = setTimeout(() => setIsWithinAFewSecondsOfRender(false), 3000)
  return () => clearTimeout(timeout)
}, [])
…
priority={inView && isWithinAFewSecondsOfRender}
```

On a web with 500 listings that's 500 timers, 500 observed elements, and 500 re-renders three seconds after load — all to stop marking images high-priority once the page has settled.

Which images are above the fold is known from their position. [MainList](components/main-list/MainList.tsx) marks the first six — two rows of the three-column grid, about a desktop viewport — and nothing else needs to watch the clock or the viewport. `useInView` leaves `Item` entirely, since feeding `priority` was its only job.

It also fixes something the old approach got wrong: everything in the viewport during the first three seconds was marked `priority`, which on a large screen could be a dozen or more images all competing at high priority. Marking everything urgent is the same as marking nothing urgent.

## The test stub was hiding this

The `next/image` stub dropped `priority`, so no test could have seen the difference. It now renders the `loading` and `fetchPriority` attributes the prop actually becomes in the browser — which is what the stub is for, standing in for "the plain `<img>` it becomes".

The new test renders nine listings and asserts six are eager. Marking them all `priority` fails it with "expected 9 to have a length of 6".

## Behaviour change worth naming

Items in the map side panel and the related-listings row on a listing page previously got `priority` if they were on screen early; they now load lazily. Neither is an LCP candidate, so that's the right default — but it is a change.

## Steps to test

1. Load a web's list view: the first two rows of images should load immediately, the rest as you scroll.
2. Scroll down quickly — later images should still appear promptly, just not pre-fetched.
3. Check the related listings on a listing page and the map's side panel still show their images.

`npm run quality:dry` is clean — 246 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)