### PR TITLE
Add security headers, and sanitize rich text before storing it

### DIFF
--- a/app/api/listing/[id]/apply-edit/route.ts
+++ b/app/api/listing/[id]/apply-edit/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import type { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -81,7 +82,7 @@ export async function POST(
 
     const newData: Prisma.ListingUpdateInput = {
       title: listingEdit.title,
-      description: listingEdit.description,
+      description: sanitizeRichText(listingEdit.description),
       website: listingEdit.website,
       email: listingEdit.email,
       socials: {

--- a/app/api/listings/[slug]/edit/route.ts
+++ b/app/api/listings/[slug]/edit/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from 'next/server'
 import { requireWebEditor } from '@/lib/api-authorization'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -71,7 +72,7 @@ export async function POST(request, props) {
     const title = formData.get('title')
     const category = Number(formData.get('category'))
     const website = formData.get('website')
-    const description = formData.get('description')
+    const description = sanitizeRichText(formData.get('description'))
     const email = formData.get('email')
     const socials = formData.get('socials')
     const socialsData = socials ? JSON.parse(socials) : []

--- a/app/api/listings/[slug]/route.ts
+++ b/app/api/listings/[slug]/route.ts
@@ -1,6 +1,7 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
 import { requireWebEditor } from '@/lib/api-authorization'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -170,7 +171,7 @@ export async function PUT(request) {
     const category = parseInt(formData.get('category'))
     const title = formData.get('title')
     const website = formData.get('website')
-    const description = formData.get('description')
+    const description = sanitizeRichText(formData.get('description'))
     const email = formData.get('email')
     const seekingVolunteers = formData.get('seekingVolunteers')
     const inactive = formData.get('inactive')

--- a/app/api/listings/import/route.ts
+++ b/app/api/listings/import/route.ts
@@ -18,6 +18,7 @@ import type {
   ImportRowResult,
 } from '@/lib/import/types'
 import { validateRows } from '@/lib/import/validator'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
 import { getSessionSafe } from '@auth'
@@ -151,7 +152,7 @@ export async function POST(request: NextRequest) {
           const listingId = await createListingWithRelations({
             listing: {
               title: row.name,
-              description: row.description,
+              description: sanitizeRichText(row.description),
               email: row.email,
               website: row.website,
               pending: false,

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -1,6 +1,7 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
 import { callerCanEditWeb, getCaller } from '@/lib/api-authorization'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import prisma from '@prisma-rw'
@@ -114,7 +115,7 @@ export async function POST(request) {
     const category = parseInt(formData.get('category'))
     const title = formData.get('title')
     const website = formData.get('website')
-    const description = formData.get('description')
+    const description = sanitizeRichText(formData.get('description'))
     const email = formData.get('email')
     const seekingVolunteers = formData.get('seekingVolunteers')
     const featured = formData.get('featured')

--- a/app/api/webs/[slug]/route.ts
+++ b/app/api/webs/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import type { NextRequest } from 'next/server'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import { Prisma } from '@prisma-client'
 import type { Web } from '@prisma/browser'
 import * as Sentry from '@sentry/nextjs'
@@ -154,7 +155,7 @@ export async function PUT(request, props) {
       title: formData.get('title'),
       published: stringToBoolean(formData.get('published')),
       contactEmail: formData.get('contactEmail'),
-      description: formData.get('description'),
+      description: sanitizeRichText(formData.get('description')),
       relations: {
         set: relationsToConnect,
       },

--- a/app/api/webs/route.ts
+++ b/app/api/webs/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server'
+import { sanitizeRichText } from '@/lib/sanitize-rich-text'
 import { Prisma } from '@prisma-client'
 import * as Sentry from '@sentry/nextjs'
 import checkWebInactiveTask from '@trigger/check-web-inactive'
@@ -127,7 +128,7 @@ export async function POST(request: NextRequest) {
       data: {
         title,
         slug,
-        description,
+        description: sanitizeRichText(description),
         contactEmail,
         published: false,
         categories: {

--- a/lib/__tests__/sanitize-rich-text.test.ts
+++ b/lib/__tests__/sanitize-rich-text.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeRichText } from '../sanitize-rich-text'
+
+const DANGEROUS =
+  /<script|<iframe|<form|<input|<button|<svg|javascript:|\son[a-z]+\s*=|url\(/i
+
+describe('sanitizeRichText', () => {
+  describe('strips anything executable', () => {
+    it.each([
+      ['a script tag', '<p>hi</p><script>fetch("//evil")</script>'],
+      [
+        'an inline event handler',
+        '<img src=x onerror="steal(document.cookie)">',
+      ],
+      ['an onmouseover handler', '<div onmouseover="alert(1)">hover</div>'],
+      ['a javascript: URL', '<a href="javascript:alert(1)">click</a>'],
+      ['an iframe', '<iframe src="//evil"></iframe>'],
+      ['an svg onload', '<svg onload="alert(1)"></svg>'],
+      ['a url() in a style', '<p style="background:url(//evil)">x</p>'],
+    ])('removes %s', (_label, input) => {
+      expect(sanitizeRichText(input)).not.toMatch(DANGEROUS)
+    })
+
+    it('removes a phishing form but keeps its visible text', () => {
+      const result = sanitizeRichText(
+        '<form action="//evil"><input name="password"><button>Sign in</button></form>',
+      )
+      expect(result).not.toMatch(DANGEROUS)
+      expect(result).toContain('Sign in')
+    })
+  })
+
+  describe('keeps what editors actually write', () => {
+    it.each([
+      [
+        'formatting',
+        '<p><strong>Bold</strong> <em>italic</em> <u>under</u></p>',
+      ],
+      ['lists', '<ul><li>one</li></ul><ol><li>two</li></ol>'],
+      ['headings and quotes', '<h2>Title</h2><blockquote>quote</blockquote>'],
+      ['tables', '<table><tbody><tr><td>a</td></tr></tbody></table>'],
+      ['alignment', '<p style="text-align:center">centered</p>'],
+      ['classes', '<div class="foo"><p class="bar">x</p></div>'],
+    ])('preserves %s', (_label, input) => {
+      expect(sanitizeRichText(input)).toBe(input)
+    })
+
+    it('keeps http, mailto and tel links', () => {
+      const input =
+        '<a href="https://example.org">web</a><a href="mailto:a@b.org">mail</a><a href="tel:+441234">call</a>'
+      expect(sanitizeRichText(input)).toBe(input)
+    })
+
+    it('keeps remote and inlined images', () => {
+      const remote =
+        '<img src="https://cdn.example.org/a.jpg" alt="a" width="200" />'
+      const inlined =
+        '<img src="data:image/png;base64,iVBORw0KGgo=" alt="logo" />'
+      expect(sanitizeRichText(remote)).toBe(remote)
+      expect(sanitizeRichText(inlined)).toBe(inlined)
+    })
+  })
+
+  it('adds rel to links opening in a new tab, which TinyMCE omits', () => {
+    expect(
+      sanitizeRichText('<a href="https://example.org" target="_blank">x</a>'),
+    ).toBe(
+      '<a href="https://example.org" target="_blank" rel="noopener noreferrer">x</a>',
+    )
+  })
+
+  it('passes non-string values through, so callers keep their null handling', () => {
+    expect(sanitizeRichText(null)).toBeNull()
+    expect(sanitizeRichText(undefined)).toBeUndefined()
+  })
+})

--- a/lib/sanitize-rich-text.ts
+++ b/lib/sanitize-rich-text.ts
@@ -1,0 +1,97 @@
+import sanitizeHtml from 'sanitize-html'
+
+// The allow-list is derived from what is actually stored — every tag, attribute
+// and style property below appears in the existing 1,578 listing and 50 web
+// descriptions — rather than from the library's defaults, so sanitising an old
+// row on its next save does not silently strip formatting someone relied on.
+//
+// Deliberately absent: script, iframe, object, embed, and form with its
+// controls. Nothing in the corpus uses them, and a form inside a listing
+// description is a phishing surface rather than a formatting choice.
+const options: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'a',
+    'article',
+    'b',
+    'blockquote',
+    'br',
+    'caption',
+    'code',
+    'dd',
+    'div',
+    'dl',
+    'dt',
+    'em',
+    'figcaption',
+    'figure',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'header',
+    'hr',
+    'i',
+    'img',
+    'li',
+    'ol',
+    'p',
+    'picture',
+    'pre',
+    'section',
+    'source',
+    'span',
+    'strong',
+    'sub',
+    'sup',
+    'table',
+    'tbody',
+    'td',
+    'tfoot',
+    'th',
+    'thead',
+    'tr',
+    'u',
+    'ul',
+    'wbr',
+  ],
+  allowedAttributes: {
+    a: ['href', 'title', 'target', 'rel'],
+    img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
+    source: ['src', 'srcset', 'sizes', 'media', 'type'],
+    '*': ['class', 'style'],
+  },
+  allowedStyles: {
+    '*': {
+      'text-align': [/^(left|right|center|justify)$/],
+      'text-decoration': [/^(underline|line-through|none)$/],
+      'font-weight': [/^(bold|normal|[1-9]00)$/],
+      'font-style': [/^(italic|normal)$/],
+    },
+  },
+  // javascript: and every other scheme is dropped. `data:` survives on images
+  // alone, because a handful of listings inline their images that way.
+  allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+  allowedSchemesByTag: { img: ['http', 'https', 'data'] },
+  transformTags: {
+    // A link opening in a new tab hands the opener to the target page unless
+    // this is set; TinyMCE does not add it.
+    a: (tagName, attribs) => ({
+      tagName,
+      attribs:
+        attribs.target === '_blank'
+          ? { ...attribs, rel: 'noopener noreferrer' }
+          : attribs,
+    }),
+  },
+}
+
+/**
+ * Strips scripts, event handlers and unsafe URLs from rich text before it is
+ * stored. Non-string input (a missing form field, null) passes through
+ * untouched so call sites keep their existing null handling.
+ */
+export function sanitizeRichText<T>(value: T): T {
+  return typeof value === 'string' ? (sanitizeHtml(value, options) as T) : value
+}

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,70 @@
 
 import { withSentryConfig } from '@sentry/nextjs'
 
+const isDev = process.env.NODE_ENV === 'development'
+
+// Sentry's CSP collector, built from the same public DSN the browser SDK
+// already ships in instrumentation-client.ts.
+const CSP_REPORT_URI =
+  'https://o4505069644611584.ingest.sentry.io/api/4505069646643200/security/?sentry_key=a205584b48c84a7fbfcd3632479d33f7'
+
+// Served as report-only. Every directive below is believed correct, but a
+// wrong one silently breaks the site for everyone, so it collects violations
+// in Sentry first and gets promoted to `Content-Security-Policy` once a week
+// of real traffic comes back quiet.
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  // Next inlines hydration payloads into prerendered HTML, and a nonce cannot
+  // be baked into a page generated at build time — so 'unsafe-inline' is
+  // unavoidable here, and this policy is *not* what stops an injected inline
+  // handler. Sanitising rich text is. What this does buy: unknown script
+  // origins are blocked, and connect-src bounds where a payload could send
+  // anything it managed to read.
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://cdn.tiny.cloud https://eu-assets.i.posthog.com`,
+  "style-src 'self' 'unsafe-inline' https://cdn.tiny.cloud",
+  "font-src 'self' data: https://cdn.tiny.cloud",
+  // Listing descriptions embed images from arbitrary hosts by design, so an
+  // origin list would be permanently incomplete. Images are not executable.
+  "img-src 'self' data: blob: https:",
+  "media-src 'self' https:",
+  [
+    "connect-src 'self'",
+    'https://eu.i.posthog.com',
+    'https://eu-assets.i.posthog.com',
+    'https://*.ingest.sentry.io',
+    'https://*.ingest.de.sentry.io',
+    'https://nominatim.openstreetmap.org',
+    'https://cdn.tiny.cloud',
+  ].join(' '),
+  // TinyMCE renders its editor into a blob: iframe.
+  "frame-src 'self' blob:",
+  "worker-src 'self' blob:",
+  "manifest-src 'self'",
+  'upgrade-insecure-requests',
+  `report-uri ${CSP_REPORT_URI}`,
+].join('; ')
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy-Report-Only', value: contentSecurityPolicy },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+  },
+  // No `preload` — that is a one-way door that needs a deliberate submission.
+  // includeSubDomains covers every web's subdomain, all of which are HTTPS.
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains',
+  },
+]
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -72,6 +136,10 @@ const nextConfig = {
   skipTrailingSlashRedirect: true,
   async headers() {
     return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
       {
         source: '/api/contact',
         headers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "remark": "15.0.1",
         "remark-html": "16.0.1",
         "resend": "6.22.1",
+        "sanitize-html": "2.17.7",
         "sharp": "0.35.3",
         "sonner": "2.0.8",
         "tailwindcss-animate": "1.0.7",
@@ -11010,6 +11011,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -11093,7 +11100,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11772,7 +11778,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -14207,6 +14212,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+      "integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -14756,6 +14770,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/leac": {
@@ -16677,6 +16700,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
@@ -16996,7 +17025,6 @@
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
       "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18668,6 +18696,125 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.7",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
+      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^12.0.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "remark": "15.0.1",
     "remark-html": "16.0.1",
     "resend": "6.22.1",
+    "sanitize-html": "2.17.7",
     "sharp": "0.35.3",
     "sonner": "2.0.8",
     "tailwindcss-animate": "1.0.7",


### PR DESCRIPTION
Findings 02 and 03 from the security review. They ship together because they are
one control between them: the sanitizer removes the injection, the CSP contains
whatever gets past it.

## 1. Security headers

The app shipped none. The only entry in `headers()` was a permissive CORS block
for `/api/contact`, and there is no `netlify.toml` or `public/_headers` either.

Six headers now apply to `/:path*`, verified present on static, dynamic and API
routes alike:

```
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
X-Frame-Options: DENY
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
Strict-Transport-Security: max-age=63072000; includeSubDomains
Content-Security-Policy-Report-Only: …
```

Two deliberate calls:

- **No HSTS `preload`.** That is a one-way door and wants its own decision.
- **`geolocation=()`** only because nothing in the codebase calls it — checked
  before disabling.

### The CSP ships report-only

Every directive is derived from what the code actually loads — `cdn.tiny.cloud`
for TinyMCE, the PostHog hosts from `app/PostHogPageView.tsx`,
`nominatim.openstreetmap.org` for geosearch, `blob:` frames because TinyMCE
renders its editor into one. But client-side loads cannot be exercised without a
browser, and a wrong directive breaks the site silently for everyone. So it
collects violations at Sentry's CSP endpoint first, and gets promoted to
`Content-Security-Policy` once a week of real traffic comes back quiet.

> **Worth setting expectations:** `script-src` needs `'unsafe-inline'` and there
> is no way around it — Next inlines hydration payloads into prerendered HTML,
> and a nonce cannot be baked into a page generated at build time. So this CSP
> **will not stop an injected inline handler.** What it buys is narrower but
> real: unknown script origins are blocked, and `connect-src` bounds where a
> payload could send anything it managed to read. Part 2 is the actual fix.

`'unsafe-eval'` is included in development only, for HMR, and confirmed absent
from the production header.

## 2. Sanitize rich text on write

`RichText` renders `listing.description` and `web.description` straight through
`dangerouslySetInnerHTML`, and no sanitizer was installed. Two ways in:

- **Any web editor, with no review at all** — they author descriptions in
  TinyMCE and the HTML renders as-is to every visitor of their web.
- **Any registered user**, via `POST /api/listings/[slug]/edit`, which correctly
  requires only a session since that is the point of the propose-edit workflow.
  The review screen renders proposals as text, so a bare `<script>` would be
  visible — but `<img src=x onerror=…>` inside ordinary copy reads as normal
  markup, and reviewers approve on content, not markup.

New `lib/sanitize-rich-text.ts`, applied at all seven write paths:

| Route | Field |
|---|---|
| `listings/route.ts` | new listing |
| `listings/[slug]/route.ts` | listing update |
| `listings/[slug]/edit/route.ts` | proposed edit |
| `listing/[id]/apply-edit/route.ts` | edit merged into the listing |
| `listings/import/route.ts` | CSV import |
| `webs/route.ts` | new web |
| `webs/[slug]/route.ts` | web update |

`apply-edit` is included even though it accepts nothing from the user directly:
it is the write path into the live listing, and pending `ListingEdit` rows
created before this change were never sanitized.

### The allow-list is derived from the data, not from defaults

Rather than guess, I scanned what is actually stored. Across **1,578 listings,
50 webs and 64 pending edits** there are zero iframes, scripts, `on*` handlers
or `javascript:` URLs — but 182 rows use `class`, 55 use `target="_blank"`, 44
use inline styles and 3 inline their images as `data:` URIs. The allow-list
covers all of those, so sanitising an old row on its next save does not silently
strip formatting someone relied on. `style` is narrowed to four text properties,
`data:` survives on `<img>` only, and `target="_blank"` gains
`rel="noopener noreferrer"`, which TinyMCE omits.

Dropped: `script`, `iframe`, `object`, `embed`, and `form` with its controls.
Exactly one listing contains a `<form>`, which is pasted junk rather than a
formatting choice.

### Scope limit

This is **write-only sanitisation**, as requested — no sanitising on read.
Existing rows are cleaned when someone next saves them. That is safe today
precisely because the scan above found the stored corpus already clean, but it
does mean a row that is already dirty stays dirty until re-saved. If that
matters, a one-off backfill is the follow-up.

## Testing

| Check | Result |
|---|---|
| Headers present on `/`, `/map`, `/kingston/web`, `/api/webs/for-sitemap` | 6/6 each, all 200 |
| `/api/contact` CORS entry preserved | yes |
| Sanitizer vs. 8 attack payloads | 0 survived |
| Sanitizer vs. 11 real-content samples | 0 altered |
| New unit tests | 18 passing |
| Same tests with the sanitizer disabled | 9 fail — confirms they test the behaviour |
| `npm run test` | 267 passing, 19 files |
| `npm run test:integration` | 142 passing, 13 files |
| `tsc` / `eslint` / `prettier` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
